### PR TITLE
feature: add basic right join support for DQL building

### DIFF
--- a/packages/dql/docs/writing_dql_clauses.md
+++ b/packages/dql/docs/writing_dql_clauses.md
@@ -93,7 +93,7 @@ class PropertyIsEmpty implements ClauseInterface
 {
     private $paths;
     public function __construct(array $propertyPath) {
-        $this->paths = [new PropertyPath('', PropertyPath::DIRECT, ...$propertyPath)];
+        $this->paths = [new PropertyPath(null, '', PropertyPath::DIRECT, ...$propertyPath)];
     }
     public function getClauseValues(): iterable
     {
@@ -172,7 +172,7 @@ class PropertyHasValue implements ClauseInterface
     private $paths;
     public function __construct($value, array $propertyPath) {
         $this->values = [$value];
-        $this->paths = [new PropertyPath('', PropertyPath::DIRECT, ...$propertyPath)];
+        $this->paths = [new PropertyPath(null, '', PropertyPath::DIRECT, ...$propertyPath)];
     }
     public function getClauseValues(): iterable
     {
@@ -260,7 +260,7 @@ class PropertyAscending implements OrderByInterface
     private $paths;
     public function __construct(array $propertyPath)
     {
-        $this->paths = [new PropertyPath('', PropertyPath::DIRECT, ...$propertyPath)];
+        $this->paths = [new PropertyPath(null, '', PropertyPath::DIRECT, ...$propertyPath)];
     }
     public function getPropertyPaths(): iterable
     {
@@ -315,8 +315,8 @@ class SizeMinusLengthAscending implements OrderByInterface
     public function __construct(array $sizePath, array $lengthPath)
     {
         $this->paths = [
-            new PropertyPath('', PropertyPath::DIRECT, ...$sizePath),
-            new PropertyPath('', PropertyPath::UNPACK, ...$lengthPath)
+            new PropertyPath(null, '', PropertyPath::DIRECT, ...$sizePath),
+            new PropertyPath(null, '', PropertyPath::UNPACK, ...$lengthPath)
         ];
     }
     public function getPropertyPaths(): iterable
@@ -357,7 +357,7 @@ class PropertyWithDefaultAscending implements OrderByInterface
     private $values;
     public function __construct(array $propertyPath, $value)
     {
-        $this->paths = [new PropertyPath('', PropertyPath::UNPACK, ...$propertyPath)];
+        $this->paths = [new PropertyPath(null, '', PropertyPath::UNPACK, ...$propertyPath)];
         $this->values = [$value];
     }
     public function getPropertyPaths(): array

--- a/packages/dql/src/ConditionFactories/DqlConditionFactory.php
+++ b/packages/dql/src/ConditionFactories/DqlConditionFactory.php
@@ -79,13 +79,15 @@ class DqlConditionFactory implements ConditionFactoryInterface
     }
 
     /**
+     * @param class-string|null $rightEntityClass
+     *
      * @return ClauseFunctionInterface<bool>
      * @throws PathException
      */
-    public function propertiesEqual(array $leftPropertyPath, array $rightPropertyPath): FunctionInterface
+    public function propertiesEqual(array $leftPropertyPath, array $rightPropertyPath, string $rightEntityClass = null, string $salt = ''): FunctionInterface
     {
         $leftPropertyPathInstance = new PropertyPath(null, '', PropertyPathAccessInterface::UNPACK, ...$leftPropertyPath);
-        $rightPropertyPathInstance = new PropertyPath(null, '', PropertyPathAccessInterface::UNPACK, ...$rightPropertyPath);
+        $rightPropertyPathInstance = new PropertyPath($rightEntityClass, $salt, PropertyPathAccessInterface::UNPACK, ...$rightPropertyPath);
         return new AllEqual(
             new Property($leftPropertyPathInstance),
             new Property($rightPropertyPathInstance)

--- a/packages/dql/src/ConditionFactories/DqlConditionFactory.php
+++ b/packages/dql/src/ConditionFactories/DqlConditionFactory.php
@@ -84,8 +84,8 @@ class DqlConditionFactory implements ConditionFactoryInterface
      */
     public function propertiesEqual(array $leftPropertyPath, array $rightPropertyPath): FunctionInterface
     {
-        $leftPropertyPathInstance = new PropertyPath('', PropertyPathAccessInterface::UNPACK, ...$leftPropertyPath);
-        $rightPropertyPathInstance = new PropertyPath('', PropertyPathAccessInterface::UNPACK, ...$rightPropertyPath);
+        $leftPropertyPathInstance = new PropertyPath(null, '', PropertyPathAccessInterface::UNPACK, ...$leftPropertyPath);
+        $rightPropertyPathInstance = new PropertyPath(null, '', PropertyPathAccessInterface::UNPACK, ...$rightPropertyPath);
         return new AllEqual(
             new Property($leftPropertyPathInstance),
             new Property($rightPropertyPathInstance)
@@ -100,7 +100,7 @@ class DqlConditionFactory implements ConditionFactoryInterface
      */
     public function propertyBetweenValuesInclusive($min, $max, string $property, string ...$propertyPath): FunctionInterface
     {
-        $propertyPathInstance = new PropertyPath('', PropertyPathAccessInterface::UNPACK, $property, ...$propertyPath);
+        $propertyPathInstance = new PropertyPath(null, '', PropertyPathAccessInterface::UNPACK, $property, ...$propertyPath);
         return new BetweenInclusive(
             new Value($min),
             new Value($max),
@@ -114,7 +114,7 @@ class DqlConditionFactory implements ConditionFactoryInterface
      */
     public function propertyHasAnyOfValues(array $values, string $property, string ...$properties): FunctionInterface
     {
-        $propertyPath = new PropertyPath('', PropertyPathAccessInterface::UNPACK, $property, ...$properties);
+        $propertyPath = new PropertyPath(null, '', PropertyPathAccessInterface::UNPACK, $property, ...$properties);
         if ([] === $values) {
             return $this->false();
         }
@@ -128,7 +128,7 @@ class DqlConditionFactory implements ConditionFactoryInterface
      */
     public function propertyHasSize(int $size, string $property, string ...$properties): FunctionInterface
     {
-        $propertyPath = new PropertyPath('', PropertyPathAccessInterface::DIRECT, $property, ...$properties);
+        $propertyPath = new PropertyPath(null, '', PropertyPathAccessInterface::DIRECT, $property, ...$properties);
         return new AllEqual(
             new Size(new Property($propertyPath)),
             new Value($size)
@@ -141,7 +141,7 @@ class DqlConditionFactory implements ConditionFactoryInterface
      */
     public function propertyHasStringContainingCaseInsensitiveValue(string $value, string $property, string ...$properties): FunctionInterface
     {
-        $propertyPath = new PropertyPath('', PropertyPathAccessInterface::UNPACK, $property, ...$properties);
+        $propertyPath = new PropertyPath(null, '', PropertyPathAccessInterface::UNPACK, $property, ...$properties);
         return new StringContains(
             new LowerCase(new Property($propertyPath)),
             new LowerCase(new Value("$value"))
@@ -156,7 +156,7 @@ class DqlConditionFactory implements ConditionFactoryInterface
      */
     public function propertyHasValue($value, string $property, string ...$properties): FunctionInterface
     {
-        $propertyPath = new PropertyPath('', PropertyPathAccessInterface::UNPACK, $property, ...$properties);
+        $propertyPath = new PropertyPath(null, '', PropertyPathAccessInterface::UNPACK, $property, ...$properties);
         return new AllEqual(
             new Property($propertyPath),
             new Value($value)
@@ -182,7 +182,7 @@ class DqlConditionFactory implements ConditionFactoryInterface
          * current Doctrine implementation the join is still needed in case of a one-to-one
          * relationship with the right side being the owning side.
          */
-        $propertyPath = new PropertyPath('', PropertyPathAccessInterface::UNPACK, $property, ...$properties);
+        $propertyPath = new PropertyPath(null, '', PropertyPathAccessInterface::UNPACK, $property, ...$properties);
         return new IsNull(new Property($propertyPath));
     }
 
@@ -192,7 +192,7 @@ class DqlConditionFactory implements ConditionFactoryInterface
      */
     public function propertyHasStringAsMember(string $value, string $property, string ...$properties): FunctionInterface
     {
-        $propertyPath = new PropertyPath('', PropertyPathAccessInterface::DIRECT, $property, ...$properties);
+        $propertyPath = new PropertyPath(null, '', PropertyPathAccessInterface::DIRECT, $property, ...$properties);
         return new IsMemberOf(
             new Property($propertyPath),
             new Value($value)
@@ -207,7 +207,7 @@ class DqlConditionFactory implements ConditionFactoryInterface
      */
     public function valueGreaterThan($value, string $property, string ...$properties): FunctionInterface
     {
-        $propertyPath = new PropertyPath('', PropertyPathAccessInterface::DIRECT, $property, ...$properties);
+        $propertyPath = new PropertyPath(null, '', PropertyPathAccessInterface::DIRECT, $property, ...$properties);
         return new Greater(
             new Property($propertyPath),
             new Value($value)
@@ -222,7 +222,7 @@ class DqlConditionFactory implements ConditionFactoryInterface
      */
     public function valueGreaterEqualsThan($value, string $property, string ...$properties): FunctionInterface
     {
-        $propertyPath = new PropertyPath('', PropertyPathAccessInterface::DIRECT, $property, ...$properties);
+        $propertyPath = new PropertyPath(null, '', PropertyPathAccessInterface::DIRECT, $property, ...$properties);
         return new GreaterEquals(
             new Property($propertyPath),
             new Value($value)
@@ -236,7 +236,7 @@ class DqlConditionFactory implements ConditionFactoryInterface
      */
     public function valueSmallerThan($value, string $property, string ...$properties): FunctionInterface
     {
-        $propertyPath = new PropertyPath('', PropertyPathAccessInterface::DIRECT, $property, ...$properties);
+        $propertyPath = new PropertyPath(null, '', PropertyPathAccessInterface::DIRECT, $property, ...$properties);
         return new Smaller(
             new Property($propertyPath),
             new Value($value)
@@ -251,7 +251,7 @@ class DqlConditionFactory implements ConditionFactoryInterface
      */
     public function valueSmallerEqualsThan($value, string $property, string ...$properties): FunctionInterface
     {
-        $propertyPath = new PropertyPath('', PropertyPathAccessInterface::DIRECT, $property, ...$properties);
+        $propertyPath = new PropertyPath(null, '', PropertyPathAccessInterface::DIRECT, $property, ...$properties);
         return new SmallerEquals(
             new Property($propertyPath),
             new Value($value)
@@ -264,7 +264,7 @@ class DqlConditionFactory implements ConditionFactoryInterface
      */
     public function propertyStartsWithCaseInsensitive(string $value, string $property, string ...$properties): FunctionInterface
     {
-        $propertyPath = new PropertyPath('', PropertyPathAccessInterface::DIRECT, $property, ...$properties);
+        $propertyPath = new PropertyPath(null, '', PropertyPathAccessInterface::DIRECT, $property, ...$properties);
         return new StringStartsWith(
             new LowerCase(new Property($propertyPath)),
             new LowerCase(new Value($value))
@@ -277,7 +277,7 @@ class DqlConditionFactory implements ConditionFactoryInterface
      */
     public function propertyEndsWithCaseInsensitive(string $value, string $property, string ...$properties): FunctionInterface
     {
-        $propertyPath = new PropertyPath('', PropertyPathAccessInterface::DIRECT, $property, ...$properties);
+        $propertyPath = new PropertyPath(null, '', PropertyPathAccessInterface::DIRECT, $property, ...$properties);
         return new StringEndsWith(
             new LowerCase(new Property($propertyPath)),
             new LowerCase(new Value($value))

--- a/packages/dql/src/Contracts/MappingException.php
+++ b/packages/dql/src/Contracts/MappingException.php
@@ -19,4 +19,16 @@ class MappingException extends Exception
     {
         return new self("Only LEFT JOIN and INNER JOIN are supported: {$joinType}");
     }
+
+    /**
+     * @param class-string $existingContext
+     * @param class-string $context
+     */
+    public static function conflictingContext(
+        string $existingContext,
+        string $context,
+        string $contextAlias
+    ): self {
+        return new self("Path defines the class context '$context' with the alias '$contextAlias', but that alias is already in use for the class context '$existingContext'.");
+    }
 }

--- a/packages/dql/src/SortMethodFactories/SortMethodFactory.php
+++ b/packages/dql/src/SortMethodFactories/SortMethodFactory.php
@@ -22,7 +22,7 @@ class SortMethodFactory implements SortMethodFactoryInterface
      */
     public function propertyAscending(string $property, string ...$properties): SortMethodInterface
     {
-        $propertyPath = new PropertyPath('', PropertyPathAccessInterface::UNPACK_RECURSIVE, $property, ...$properties);
+        $propertyPath = new PropertyPath(null, '', PropertyPathAccessInterface::UNPACK_RECURSIVE, $property, ...$properties);
         return new Ascending(new Property($propertyPath));
     }
 
@@ -32,7 +32,7 @@ class SortMethodFactory implements SortMethodFactoryInterface
      */
     public function propertyDescending(string $property, string ...$properties): SortMethodInterface
     {
-        $propertyPath = new PropertyPath('', PropertyPathAccessInterface::UNPACK_RECURSIVE, $property, ...$properties);
+        $propertyPath = new PropertyPath(null, '', PropertyPathAccessInterface::UNPACK_RECURSIVE, $property, ...$properties);
         return new Descending(new Property($propertyPath));
     }
 }

--- a/packages/dql/src/Utilities/QueryBuilderPreparer.php
+++ b/packages/dql/src/Utilities/QueryBuilderPreparer.php
@@ -18,6 +18,8 @@ use EDT\DqlQuerying\Contracts\MappingException;
 use EDT\DqlQuerying\Contracts\OrderByInterface;
 use EDT\Querying\Contracts\PropertyPathAccessInterface;
 use EDT\Querying\Utilities\Iterables;
+use ReflectionException;
+use function array_key_exists;
 use function array_slice;
 use function count;
 
@@ -38,6 +40,11 @@ class QueryBuilderPreparer
     private $joinClauses = [];
 
     /**
+     * @var array<string,class-string> mapping from the alias to the entity type
+     */
+    private $fromClauses = [];
+
+    /**
      * Mapping from (integer) parameter key to parameter value.
      * Using {@see Parameter} would be possible too but
      * seems more complex and not necessary.
@@ -54,7 +61,7 @@ class QueryBuilderPreparer
      *
      * @var ClassMetadataInfo
      */
-    private $classMetadata;
+    private $mainClassMetadata;
 
     /**
      * @var array<int,ClauseInterface>
@@ -65,6 +72,11 @@ class QueryBuilderPreparer
      * @var OrderByInterface[]
      */
     private $sortMethods = [];
+
+    /**
+     * @var ClassMetadataFactory
+     */
+    private $metadataFactory;
 
     /**
      * Transform the given group into raw DQL query data using the given entity definition.
@@ -79,7 +91,8 @@ class QueryBuilderPreparer
     public function __construct(string $mainEntityClass, ClassMetadataFactory $metadataFactory)
     {
         $this->joinFinder = new JoinFinder($metadataFactory);
-        $this->classMetadata = $metadataFactory->getMetadataFor($mainEntityClass);
+        $this->metadataFactory = $metadataFactory;
+        $this->mainClassMetadata = $metadataFactory->getMetadataFor($mainEntityClass);
     }
 
     /**
@@ -110,27 +123,46 @@ class QueryBuilderPreparer
     public function fillQueryBuilder(QueryBuilder $queryBuilder): void
     {
         // start filling the actual query
-        $entityAlias = $this->classMetadata->getTableName();
+        $entityAlias = $this->mainClassMetadata->getTableName();
         $queryBuilder->select($entityAlias);
-        $queryBuilder->from($this->classMetadata->getName(), $entityAlias);
+        $queryBuilder->from($this->mainClassMetadata->getName(), $entityAlias);
 
         // Side effects! Execution order matters!
-        // While setting WHERE and ORDER BY the joins and parameters are determined.
-        $this->setWhere($queryBuilder);
-        $this->setOrderBy($queryBuilder);
-        $this->setParameters($queryBuilder);
+        // Process all conditions and sort methods to collect `from`s, joins and parameters
+        // before setting those.
+        $whereExpressions = array_map([$this, 'processClause'], $this->conditions);
+        $orderExpressions = array_map([$this, 'processClause'], $this->sortMethods);
+
+        // set additional `from`s
+        array_map([$queryBuilder, 'from'], $this->fromClauses, array_keys($this->fromClauses));
+
+        // set `JOIN`s
         $this->setJoins($queryBuilder);
+
+        // set `WHERE`s
+        if ([] !== $whereExpressions) {
+            // Set the 'WHERE' expressions that resulted from the given clause.
+            // Each expression includes all nested conditions if any are present.
+            $queryBuilder->where(...$whereExpressions);
+        }
+
+        // set `ORDER BY`s
+        $orderings = array_map([$this, 'createOrderBy'], $orderExpressions, $this->sortMethods);
+        array_map([$queryBuilder, 'addOrderBy'], $orderings);
+
+        // set parameters
+        $queryBuilder->setParameters($this->parameters);
+
         $this->resetTemporaryState();
     }
 
     /**
      * @throws MappingException
      */
-    protected function processSortingClause(OrderByInterface $sortClause): OrderBy
+    protected function createOrderBy($orderByDql, OrderByInterface $sortClause): OrderBy
     {
-        $dql = $this->processClause($sortClause);
         $direction = $sortClause->getDirection();
-        return new OrderBy((string)$dql, $direction);
+        return new OrderBy((string)$orderByDql, $direction);
     }
 
     /**
@@ -143,15 +175,16 @@ class QueryBuilderPreparer
         $clauseValues = Iterables::asArray($clause->getClauseValues());
         $valueIndices = array_map([$this, 'addToParameters'], $clauseValues);
         $columnNames = array_map(function (PropertyPathAccessInterface $path): string {
-            return $this->processPath($path->getSalt(), $path->getAccessDepth(), ...iterator_to_array($path));
+            return $this->processPath($path->getSalt(), $path->getAccessDepth(), $path->getContext(), ...iterator_to_array($path));
         }, Iterables::asArray($clause->getPropertyPaths()));
 
         return $clause->asDql($valueIndices, $columnNames);
     }
 
     /**
-     * Processes the path to find all necessary joins. The joins found are added to
-     * {@link QueryBuilderPreparer::$joinClauses}.
+     * Processes the path to find all necessary joins and `from` clauses. The joins found are added to
+     * {@link QueryBuilderPreparer::$joinClauses}. The `from` clauses found are added to
+     * {@link QueryBuilderPreparer::$fromClauses}.
      *
      * @param int $accessDepth 1 if the last property in the given path is a relationship
      *                         and a join needs to be created from that relationship property
@@ -161,18 +194,23 @@ class QueryBuilderPreparer
      *                         and no join should be created from that relationship property
      *                         to its target entity. In that case the alias to the join
      *                         will be returned (with appended property name).
+     * @param class-string|null $context non-`null` if a different context (i.e. a separate `from`
+     *                                   clause should be used for the current path
      *
      * @return string The alias of the entity at the end of the path with or without appended property name.
      *
      * @throws MappingException
+     * @throws \Doctrine\Persistence\Mapping\MappingException
+     * @throws ReflectionException
      */
-    protected function processPath(string $salt, int $accessDepth, string $property, string ...$properties): string
+    protected function processPath(string $salt, int $accessDepth, ?string $context, string $property, string ...$properties): string
     {
         array_unshift($properties, $property);
         $originalPathLength = count($properties);
+        $inMainContext = null === $context;
 
         /**
-         * If the condition acts on the relationship name (ie. does not need a join to the target
+         * If the condition acts on the relationship name (i.e. does not need a join to the target
          * entity) we do not look for joins at the path parts after the relationship and thus remove
          * it here. For more information see {@link PropertyPathAccessInterface::getAccessDepth()}.
          */
@@ -186,7 +224,26 @@ class QueryBuilderPreparer
             $lastProperty = $properties[array_key_last($properties)];
         }
 
-        $neededJoins = $this->joinFinder->findNecessaryJoins($salt, $this->classMetadata, $properties);
+        if ($inMainContext) {
+            $classMetadata = $this->mainClassMetadata;
+        } else {
+            $classMetadata = $this->metadataFactory->getMetadataFor($context);
+            $this->addFromClause($context, $this->joinFinder->createTableAlias($salt, $classMetadata));
+        }
+
+
+        // For the main context the simple table name will be used to match the alias in the main `from` clause.
+        // Separate contexts will be prefixed to distinguish them if they use the same table name as the main context.
+        $entityAlias = $inMainContext
+            ? $classMetadata->getTableName()
+            : $this->joinFinder->createTableAlias($salt, $classMetadata);
+
+        $neededJoins = $this->joinFinder->findNecessaryJoins(
+            $salt,
+            $classMetadata,
+            $properties,
+            $entityAlias
+        );
         $lastPropertyWasRelationship = count($neededJoins) === $originalPathLength;
 
         if (0 !== count($neededJoins)) {
@@ -194,7 +251,7 @@ class QueryBuilderPreparer
             // Will override duplicated keys, this is ok, as we expect the key
             // to be the join alias and the join alias to be unique except
             // it actually corresponds to the exactly same join clause.
-            $this->joinClauses = array_merge($this->joinClauses, $this->useAliasAsKey($neededJoins));
+            $this->joinClauses = array_merge($this->joinClauses, $neededJoins);
 
             // As there were joins needed to access the property the accessed entity is now the last
             // join determined above.
@@ -205,7 +262,7 @@ class QueryBuilderPreparer
             // If the condition needs to access a property directly on the entity we append the
             // property name to the entity alias.
             if (!$lastPropertyWasRelationship || $dropProperties) {
-                return "{$entityAlias}.{$lastProperty}";
+                return "$entityAlias.$lastProperty";
             }
 
             /**
@@ -222,22 +279,7 @@ class QueryBuilderPreparer
 
         // If no joins are needed for this condition we can simply use the root entity alias with
         // the accessed property appended.
-        return "{$this->classMetadata->getTableName()}.$lastProperty";
-    }
-
-    /**
-     * @param array<int,Join>|Join[] $joins
-     *
-     * @return array<string,Join>|Join[]
-     */
-    protected function useAliasAsKey(array $joins): array
-    {
-        $result = [];
-        foreach ($joins as $join) {
-            $result[$join->getAlias()] = $join;
-        }
-
-        return $result;
+        return "$entityAlias.$lastProperty";
     }
 
     /**
@@ -252,35 +294,6 @@ class QueryBuilderPreparer
     {
         $parameterIndex = array_push($this->parameters, $value) - 1;
         return "?{$parameterIndex}";
-    }
-
-    /**
-     * @throws MappingException
-     */
-    private function setWhere(QueryBuilder $queryBuilder): void
-    {
-        if ([] !== $this->conditions) {
-            // The 'WHERE' expressions that resulted from the given clause.
-            // Each expression includes all nested conditions if any are present.
-            $whereExpressions = array_map([$this, 'processClause'], $this->conditions);
-            $queryBuilder->where(...$whereExpressions);
-        }
-    }
-
-    /**
-     * @throws MappingException
-     */
-    private function setOrderBy(QueryBuilder $queryBuilder): void
-    {
-        if ([] !== $this->sortMethods) {
-            $orderings = array_map([$this, 'processSortingClause'], $this->sortMethods);
-            array_map([$queryBuilder, 'addOrderBy'], $orderings);
-        }
-    }
-
-    private function setParameters(QueryBuilder $queryBuilder): void
-    {
-        $queryBuilder->setParameters($this->parameters);
     }
 
     /**
@@ -318,5 +331,22 @@ class QueryBuilderPreparer
     {
         $this->joinClauses = [];
         $this->parameters = [];
+    }
+
+    /**
+     * @param class-string $context
+     *
+     * @throws MappingException
+     */
+    private function addFromClause(string $context, string $tableAlias): void
+    {
+        if (array_key_exists($tableAlias, $this->fromClauses)) {
+            $existingContext = $this->fromClauses[$tableAlias];
+            if ($existingContext !== $context) {
+                throw MappingException::conflictingContext($existingContext, $context, $tableAlias);
+            }
+        } else {
+            $this->fromClauses[$tableAlias] = $context;
+        }
     }
 }

--- a/packages/dql/src/Utilities/QueryBuilderPreparer.php
+++ b/packages/dql/src/Utilities/QueryBuilderPreparer.php
@@ -49,6 +49,9 @@ class QueryBuilderPreparer
     private $parameters = [];
 
     /**
+     * Provides all needed information to choose the correct entity type and mappings to translate
+     * the group into DQL data.
+     *
      * @var ClassMetadataInfo
      */
     private $classMetadata;
@@ -56,12 +59,12 @@ class QueryBuilderPreparer
     /**
      * @var array<int,ClauseInterface>
      */
-    private $conditions;
+    private $conditions = [];
 
     /**
      * @var OrderByInterface[]
      */
-    private $sortMethods;
+    private $sortMethods = [];
 
     /**
      * Transform the given group into raw DQL query data using the given entity definition.
@@ -71,15 +74,12 @@ class QueryBuilderPreparer
      * given group. The joins required to limit the result will be automatically generated
      * using the group and entity definition.
      *
-     * @param ClassMetadataInfo $classMetadata Provides all needed information to
-     *                                         choose the correct entity type and
-     *                                         mappings to translate the group
-     *                                         into DQL data.
+     * @param class-string $mainEntityClass the entity class to fetch instances of
      */
-    public function __construct(ClassMetadataInfo $classMetadata, ClassMetadataFactory $metadataFactory)
+    public function __construct(string $mainEntityClass, ClassMetadataFactory $metadataFactory)
     {
         $this->joinFinder = new JoinFinder($metadataFactory);
-        $this->classMetadata = $classMetadata;
+        $this->classMetadata = $metadataFactory->getMetadataFor($mainEntityClass);
     }
 
     /**

--- a/packages/dql/src/Utilities/QueryGenerator.php
+++ b/packages/dql/src/Utilities/QueryGenerator.php
@@ -34,8 +34,8 @@ class QueryGenerator
     public function generateQueryBuilder(string $entityClass, array $conditions, array $sortMethods = [], int $offset = 0, int $limit = null): QueryBuilder
     {
         $queryBuilder = $this->entityManager->createQueryBuilder();
-        $classMetadata = $this->entityManager->getClassMetadata($entityClass);
-        $builderPreparer = new QueryBuilderPreparer($classMetadata, $this->entityManager->getMetadataFactory());
+        $metadataFactory = $this->entityManager->getMetadataFactory();
+        $builderPreparer = new QueryBuilderPreparer($entityClass, $metadataFactory);
         $builderPreparer->setWhereExpressions(...$conditions);
         $builderPreparer->setOrderByExpressions(...$sortMethods);
         $builderPreparer->fillQueryBuilder($queryBuilder);

--- a/packages/dql/tests/DqlQuerying/Utilities/JoinFinderTest.php
+++ b/packages/dql/tests/DqlQuerying/Utilities/JoinFinderTest.php
@@ -56,41 +56,41 @@ class JoinFinderTest extends TestCase
 
     public function testAuthor(): void
     {
-        $joins = $this->joinFinder->findNecessaryJoins('', $this->bookMetadata, ['author']);
+        $joins = $this->joinFinder->findNecessaryJoins('', $this->bookMetadata, ['author'], $this->bookMetadata->getTableName());
         $firstJoin = array_shift($joins);
-        $this->checkJoin($firstJoin, 'Book.author', 't_bdafd8c8_Person');
+        $this->checkJoin($firstJoin, 'Book.author', 't_58fb870d_Person');
     }
 
     public function testTitle(): void
     {
-        $joins = $this->joinFinder->findNecessaryJoins('', $this->bookMetadata, ['title']);
+        $joins = $this->joinFinder->findNecessaryJoins('', $this->bookMetadata, ['title'], $this->bookMetadata->getTableName());
 
         self::assertCount(0, $joins);
     }
 
     public function testName(): void
     {
-        $joins = $this->joinFinder->findNecessaryJoins('', $this->bookMetadata, ['author', 'name']);
+        $joins = $this->joinFinder->findNecessaryJoins('', $this->bookMetadata, ['author', 'name'], $this->bookMetadata->getTableName());
         $firstJoin = array_shift($joins);
-        $this->checkJoin($firstJoin, 'Book.author', 't_bdafd8c8_Person');
+        $this->checkJoin($firstJoin, 'Book.author', 't_58fb870d_Person');
     }
 
     public function testBirthplace(): void
     {
-        $joins = $this->joinFinder->findNecessaryJoins('', $this->bookMetadata, ['author', 'birth']);
+        $joins = $this->joinFinder->findNecessaryJoins('', $this->bookMetadata, ['author', 'birth'], $this->bookMetadata->getTableName());
         $firstJoin = array_shift($joins);
-        $this->checkJoin($firstJoin, 'Book.author', 't_bdafd8c8_Person');
+        $this->checkJoin($firstJoin, 'Book.author', 't_58fb870d_Person');
         $secondJoin = array_shift($joins);
-        $this->checkJoin($secondJoin, 't_bdafd8c8_Person.birth', 't_1ad451b9_Birth');
+        $this->checkJoin($secondJoin, 't_58fb870d_Person.birth', 't_7e118c84_Birth');
     }
 
     public function testStreet(): void
     {
-        $joins = $this->joinFinder->findNecessaryJoins('', $this->bookMetadata, ['author', 'birth', 'street']);
+        $joins = $this->joinFinder->findNecessaryJoins('', $this->bookMetadata, ['author', 'birth', 'street'], $this->bookMetadata->getTableName());
         $firstJoin = array_shift($joins);
-        $this->checkJoin($firstJoin, 'Book.author', 't_bdafd8c8_Person');
+        $this->checkJoin($firstJoin, 'Book.author', 't_58fb870d_Person');
         $secondJoin = array_shift($joins);
-        $this->checkJoin($secondJoin, 't_bdafd8c8_Person.birth', 't_1ad451b9_Birth');
+        $this->checkJoin($secondJoin, 't_58fb870d_Person.birth', 't_7e118c84_Birth');
     }
 
     private function checkJoin(?Join $join, string $left, string $right): void

--- a/packages/dql/tests/DqlQuerying/Utilities/QueryGeneratorTest.php
+++ b/packages/dql/tests/DqlQuerying/Utilities/QueryGeneratorTest.php
@@ -396,7 +396,7 @@ class QueryGeneratorTest extends TestCase
 
     public function testUpperCase(): void
     {
-        $propertyPath = new PropertyPath('', PropertyPathAccessInterface::UNPACK, 'title');
+        $propertyPath = new PropertyPath(null, '', PropertyPathAccessInterface::UNPACK, 'title');
         $sameUpperCase = new AllEqual(
             new UpperCase(new Property($propertyPath)),
             new Value('FOO'),
@@ -415,7 +415,7 @@ class QueryGeneratorTest extends TestCase
 
     public function testSum(): void
     {
-        $propertyPathInstance = new PropertyPath('', PropertyPathAccessInterface::UNPACK, 'name');
+        $propertyPathInstance = new PropertyPath(null, '', PropertyPathAccessInterface::UNPACK, 'name');
         $size = new Size(new Property($propertyPathInstance));
         $sum = new AllEqual(
             new Sum($size, $size),
@@ -435,7 +435,7 @@ class QueryGeneratorTest extends TestCase
 
     public function testSumAdditionalAddends(): void
     {
-        $propertyPathInstance = new PropertyPath('', PropertyPathAccessInterface::UNPACK, 'name');
+        $propertyPathInstance = new PropertyPath(null, '', PropertyPathAccessInterface::UNPACK, 'name');
         $size = new Size(new Property($propertyPathInstance));
         $sum = new AllEqual(
             new Sum($size, $size, $size, $size),
@@ -455,7 +455,7 @@ class QueryGeneratorTest extends TestCase
 
     public function testSumPowMixed(): void
     {
-        $propertyPathInstance = new PropertyPath('', PropertyPathAccessInterface::UNPACK, 'name');
+        $propertyPathInstance = new PropertyPath(null, '', PropertyPathAccessInterface::UNPACK, 'name');
         $size = new Size(new Property($propertyPathInstance));
         $sum = new AllEqual(
             new Product(
@@ -485,7 +485,7 @@ class QueryGeneratorTest extends TestCase
 
     public function testCustomMemberCondition(): void
     {
-        $propertyPath = new PropertyPath('', PropertyPathAccessInterface::DIRECT, 'books', 'title');
+        $propertyPath = new PropertyPath(null, '', PropertyPathAccessInterface::DIRECT, 'books', 'title');
         $condition = new AllTrue(
             new AllEqual(
                 new Value('Harry Potter and the Philosopher\'s Stone'),
@@ -511,8 +511,8 @@ class QueryGeneratorTest extends TestCase
 
     public function testCustomMemberConditionWithSalt(): void
     {
-        $propertyPathA = new PropertyPath('a', PropertyPathAccessInterface::DIRECT, 'books', 'title');
-        $propertyPathB = new PropertyPath('b', PropertyPathAccessInterface::DIRECT, 'books', 'title');
+        $propertyPathA = new PropertyPath(null, 'a', PropertyPathAccessInterface::DIRECT, 'books', 'title');
+        $propertyPathB = new PropertyPath(null, 'b', PropertyPathAccessInterface::DIRECT, 'books', 'title');
         $condition = new AllTrue(
             new AllEqual(
                 new Property($propertyPathA),

--- a/packages/dql/tests/DqlQuerying/Utilities/QueryGeneratorTest.php
+++ b/packages/dql/tests/DqlQuerying/Utilities/QueryGeneratorTest.php
@@ -126,7 +126,7 @@ class QueryGeneratorTest extends TestCase
         $allConditionsApply = $this->conditionFactory->allConditionsApply($bookA, $bookB);
         $queryBuilder = $this->queryGenerator->generateQueryBuilder(Person::class, [$allConditionsApply]);
         self::assertSame(
-            'SELECT Person FROM Tests\data\DqlModel\Person Person LEFT JOIN Person.books t_4a1b2a92_Book WHERE t_4a1b2a92_Book.title = ?0 AND t_4a1b2a92_Book.title = ?1',
+            'SELECT Person FROM Tests\data\DqlModel\Person Person LEFT JOIN Person.books t_3e6230ca_Book WHERE t_3e6230ca_Book.title = ?0 AND t_3e6230ca_Book.title = ?1',
             $queryBuilder->getDQL()
         );
 
@@ -142,7 +142,7 @@ class QueryGeneratorTest extends TestCase
         $propertyHasValue = $this->conditionFactory->propertyHasValue('Example Street', 'author', 'birth', 'street');
         $queryBuilder = $this->queryGenerator->generateQueryBuilder(Book::class, [$propertyHasValue]);
         self::assertSame(
-            'SELECT Book FROM Tests\data\DqlModel\Book Book LEFT JOIN Book.author t_bdafd8c8_Person LEFT JOIN t_bdafd8c8_Person.birth t_1ad451b9_Birth WHERE t_1ad451b9_Birth.street = ?0',
+            'SELECT Book FROM Tests\data\DqlModel\Book Book LEFT JOIN Book.author t_58fb870d_Person LEFT JOIN t_58fb870d_Person.birth t_7e118c84_Birth WHERE t_7e118c84_Birth.street = ?0',
             $queryBuilder->getDQL()
         );
 
@@ -163,7 +163,7 @@ class QueryGeneratorTest extends TestCase
             [$ascending, $descending]
         );
         self::assertSame(
-            'SELECT Book FROM Tests\data\DqlModel\Book Book LEFT JOIN Book.author t_bdafd8c8_Person LEFT JOIN t_bdafd8c8_Person.birth t_1ad451b9_Birth WHERE t_1ad451b9_Birth.street = ?0 ORDER BY t_1ad451b9_Birth.street ASC, Book.title DESC',
+            'SELECT Book FROM Tests\data\DqlModel\Book Book LEFT JOIN Book.author t_58fb870d_Person LEFT JOIN t_58fb870d_Person.birth t_7e118c84_Birth WHERE t_7e118c84_Birth.street = ?0 ORDER BY t_7e118c84_Birth.street ASC, Book.title DESC',
             $queryBuilder->getDQL()
         );
 
@@ -184,7 +184,7 @@ class QueryGeneratorTest extends TestCase
             [$descending, $ascending]
         );
         self::assertSame(
-            'SELECT Book FROM Tests\data\DqlModel\Book Book LEFT JOIN Book.author t_bdafd8c8_Person LEFT JOIN t_bdafd8c8_Person.birth t_1ad451b9_Birth WHERE t_1ad451b9_Birth.street = ?0 ORDER BY t_1ad451b9_Birth.street DESC, Book.title ASC',
+            'SELECT Book FROM Tests\data\DqlModel\Book Book LEFT JOIN Book.author t_58fb870d_Person LEFT JOIN t_58fb870d_Person.birth t_7e118c84_Birth WHERE t_7e118c84_Birth.street = ?0 ORDER BY t_7e118c84_Birth.street DESC, Book.title ASC',
             $queryBuilder->getDQL()
         );
 
@@ -206,7 +206,7 @@ class QueryGeneratorTest extends TestCase
             1, 3
         );
         self::assertSame(
-            'SELECT Book FROM Tests\data\DqlModel\Book Book LEFT JOIN Book.author t_bdafd8c8_Person LEFT JOIN t_bdafd8c8_Person.birth t_1ad451b9_Birth WHERE t_1ad451b9_Birth.street = ?0 ORDER BY t_1ad451b9_Birth.street ASC, Book.title DESC',
+            'SELECT Book FROM Tests\data\DqlModel\Book Book LEFT JOIN Book.author t_58fb870d_Person LEFT JOIN t_58fb870d_Person.birth t_7e118c84_Birth WHERE t_7e118c84_Birth.street = ?0 ORDER BY t_7e118c84_Birth.street ASC, Book.title DESC',
             $queryBuilder->getDQL()
         );
 
@@ -223,7 +223,7 @@ class QueryGeneratorTest extends TestCase
         $propertyIsNull = $this->conditionFactory->propertyIsNull('author', 'birth');
         $queryBuilder = $this->queryGenerator->generateQueryBuilder(Book::class, [$propertyIsNull]);
         self::assertSame(
-            'SELECT Book FROM Tests\data\DqlModel\Book Book LEFT JOIN Book.author t_bdafd8c8_Person LEFT JOIN t_bdafd8c8_Person.birth t_1ad451b9_Birth WHERE t_1ad451b9_Birth IS NULL',
+            'SELECT Book FROM Tests\data\DqlModel\Book Book LEFT JOIN Book.author t_58fb870d_Person LEFT JOIN t_58fb870d_Person.birth t_7e118c84_Birth WHERE t_7e118c84_Birth IS NULL',
             $queryBuilder->getDQL()
         );
         self::assertCount(0, $queryBuilder->getParameters());
@@ -234,7 +234,7 @@ class QueryGeneratorTest extends TestCase
         $propertyIsNull = $this->conditionFactory->propertyIsNull('author', 'birth', 'street');
         $queryBuilder = $this->queryGenerator->generateQueryBuilder(Book::class, [$propertyIsNull]);
         self::assertSame(
-            'SELECT Book FROM Tests\data\DqlModel\Book Book LEFT JOIN Book.author t_bdafd8c8_Person LEFT JOIN t_bdafd8c8_Person.birth t_1ad451b9_Birth WHERE t_1ad451b9_Birth.street IS NULL',
+            'SELECT Book FROM Tests\data\DqlModel\Book Book LEFT JOIN Book.author t_58fb870d_Person LEFT JOIN t_58fb870d_Person.birth t_7e118c84_Birth WHERE t_7e118c84_Birth.street IS NULL',
             $queryBuilder->getDQL()
         );
         self::assertCount(0, $queryBuilder->getParameters());
@@ -275,7 +275,7 @@ class QueryGeneratorTest extends TestCase
         $propertyHasNotSize = $this->conditionFactory->propertyHasNotSize(0, 'author', 'books');
         $queryBuilder = $this->queryGenerator->generateQueryBuilder(Book::class, [$propertyHasNotSize]);
         self::assertSame(
-            'SELECT Book FROM Tests\data\DqlModel\Book Book LEFT JOIN Book.author t_bdafd8c8_Person WHERE NOT(SIZE(t_bdafd8c8_Person.books) = ?0)',
+            'SELECT Book FROM Tests\data\DqlModel\Book Book LEFT JOIN Book.author t_58fb870d_Person WHERE NOT(SIZE(t_58fb870d_Person.books) = ?0)',
             $queryBuilder->getDQL()
         );
 
@@ -290,7 +290,7 @@ class QueryGeneratorTest extends TestCase
         $propertyBetween = $this->conditionFactory->propertyBetweenValuesInclusive(-1, 5, 'author', 'birth', 'streetNumber');
         $queryBuilder = $this->queryGenerator->generateQueryBuilder(Book::class, [$propertyBetween]);
         self::assertSame(
-            'SELECT Book FROM Tests\data\DqlModel\Book Book LEFT JOIN Book.author t_bdafd8c8_Person LEFT JOIN t_bdafd8c8_Person.birth t_1ad451b9_Birth WHERE t_1ad451b9_Birth.streetNumber BETWEEN ?0 AND ?1',
+            'SELECT Book FROM Tests\data\DqlModel\Book Book LEFT JOIN Book.author t_58fb870d_Person LEFT JOIN t_58fb870d_Person.birth t_7e118c84_Birth WHERE t_7e118c84_Birth.streetNumber BETWEEN ?0 AND ?1',
             $queryBuilder->getDQL()
         );
 
@@ -306,7 +306,7 @@ class QueryGeneratorTest extends TestCase
         $containsValue = $this->conditionFactory->propertyHasStringContainingCaseInsensitiveValue('Ave', 'author', 'birth', 'street');
         $queryBuilder = $this->queryGenerator->generateQueryBuilder(Book::class, [$containsValue]);
         self::assertSame(
-            "SELECT Book FROM Tests\data\DqlModel\Book Book LEFT JOIN Book.author t_bdafd8c8_Person LEFT JOIN t_bdafd8c8_Person.birth t_1ad451b9_Birth WHERE LOWER(t_1ad451b9_Birth.street) LIKE CONCAT('%', LOWER(?0), '%')",
+            "SELECT Book FROM Tests\data\DqlModel\Book Book LEFT JOIN Book.author t_58fb870d_Person LEFT JOIN t_58fb870d_Person.birth t_7e118c84_Birth WHERE LOWER(t_7e118c84_Birth.street) LIKE CONCAT('%', LOWER(?0), '%')",
             $queryBuilder->getDQL()
         );
 
@@ -321,7 +321,7 @@ class QueryGeneratorTest extends TestCase
         $containsValue = $this->conditionFactory->propertyHasAnyOfValues([1, 2, 3], 'author', 'birth', 'streetNumber');
         $queryBuilder = $this->queryGenerator->generateQueryBuilder(Book::class, [$containsValue]);
         self::assertSame(
-            'SELECT Book FROM Tests\data\DqlModel\Book Book LEFT JOIN Book.author t_bdafd8c8_Person LEFT JOIN t_bdafd8c8_Person.birth t_1ad451b9_Birth WHERE t_1ad451b9_Birth.streetNumber IN(?0)',
+            'SELECT Book FROM Tests\data\DqlModel\Book Book LEFT JOIN Book.author t_58fb870d_Person LEFT JOIN t_58fb870d_Person.birth t_7e118c84_Birth WHERE t_7e118c84_Birth.streetNumber IN(?0)',
             $queryBuilder->getDQL()
         );
 
@@ -388,7 +388,22 @@ class QueryGeneratorTest extends TestCase
         $birthDateCondition = $this->conditionFactory->propertiesEqual(['author', 'birth', 'month'], ['author', 'birth', 'day']);
         $queryBuilder = $this->queryGenerator->generateQueryBuilder(Book::class, [$birthDateCondition]);
         self::assertSame(
-            'SELECT Book FROM Tests\data\DqlModel\Book Book LEFT JOIN Book.author t_bdafd8c8_Person LEFT JOIN t_bdafd8c8_Person.birth t_1ad451b9_Birth WHERE t_1ad451b9_Birth.month = t_1ad451b9_Birth.day',
+            'SELECT Book FROM Tests\data\DqlModel\Book Book LEFT JOIN Book.author t_58fb870d_Person LEFT JOIN t_58fb870d_Person.birth t_7e118c84_Birth WHERE t_7e118c84_Birth.month = t_7e118c84_Birth.day',
+            $queryBuilder->getDQL()
+        );
+        self::assertCount(0, $queryBuilder->getParameters());
+    }
+
+    public function testPropertiesEqualWithForeignEntityClass(): void
+    {
+        $birthDateCondition = $this->conditionFactory->propertiesEqual(
+            ['author', 'birth', 'month'],
+            ['author', 'birth', 'day'],
+            Book::class
+        );
+        $queryBuilder = $this->queryGenerator->generateQueryBuilder(Book::class, [$birthDateCondition]);
+        self::assertSame(
+            'SELECT Book FROM Tests\data\DqlModel\Book Book LEFT JOIN Book.author t_58fb870d_Person LEFT JOIN t_58fb870d_Person.birth t_7e118c84_Birth, Tests\data\DqlModel\Book t__Book LEFT JOIN t__Book.author t_71115441_Person LEFT JOIN t_71115441_Person.birth t_1a171a0d_Birth WHERE t_7e118c84_Birth.month = t_1a171a0d_Birth.day',
             $queryBuilder->getDQL()
         );
         self::assertCount(0, $queryBuilder->getParameters());
@@ -498,7 +513,7 @@ class QueryGeneratorTest extends TestCase
         );
         $queryBuilder = $this->queryGenerator->generateQueryBuilder(Person::class, [$condition]);
         self::assertSame(
-            'SELECT Person FROM Tests\data\DqlModel\Person Person LEFT JOIN Person.books t_4a1b2a92_Book WHERE ?0 = t_4a1b2a92_Book.title AND ?1 = t_4a1b2a92_Book.title',
+            'SELECT Person FROM Tests\data\DqlModel\Person Person LEFT JOIN Person.books t_3e6230ca_Book WHERE ?0 = t_3e6230ca_Book.title AND ?1 = t_3e6230ca_Book.title',
             $queryBuilder->getDQL()
         );
 
@@ -525,7 +540,7 @@ class QueryGeneratorTest extends TestCase
         );
         $queryBuilder = $this->queryGenerator->generateQueryBuilder(Person::class, [$condition]);
         self::assertSame(
-            'SELECT Person FROM Tests\data\DqlModel\Person Person LEFT JOIN Person.books ta_4a1b2a92_Book LEFT JOIN Person.books tb_4a1b2a92_Book WHERE ta_4a1b2a92_Book.title = ?0 AND tb_4a1b2a92_Book.title = ?1',
+            'SELECT Person FROM Tests\data\DqlModel\Person Person LEFT JOIN Person.books t_99a6b3fc_Book LEFT JOIN Person.books t_246cdf32_Book WHERE t_99a6b3fc_Book.title = ?0 AND t_246cdf32_Book.title = ?1',
             $queryBuilder->getDQL()
         );
 
@@ -544,7 +559,7 @@ class QueryGeneratorTest extends TestCase
         ], 'books', 'title');
         $queryBuilder = $this->queryGenerator->generateQueryBuilder(Person::class, [$condition]);
         self::assertSame(
-            'SELECT Person FROM Tests\data\DqlModel\Person Person LEFT JOIN Person.books t0_4a1b2a92_Book LEFT JOIN Person.books t1_4a1b2a92_Book WHERE t0_4a1b2a92_Book.title = ?0 AND t1_4a1b2a92_Book.title = ?1',
+            'SELECT Person FROM Tests\data\DqlModel\Person Person LEFT JOIN Person.books t_4dba5d08_Book LEFT JOIN Person.books t_902c848d_Book WHERE t_4dba5d08_Book.title = ?0 AND t_902c848d_Book.title = ?1',
             $queryBuilder->getDQL()
         );
 

--- a/packages/queries/src/ConditionFactories/PhpConditionFactory.php
+++ b/packages/queries/src/ConditionFactories/PhpConditionFactory.php
@@ -53,8 +53,8 @@ class PhpConditionFactory implements ConditionFactoryInterface
 
     public function propertiesEqual(array $leftProperties, array $rightProperties): FunctionInterface
     {
-        $leftPropertyPath = new PropertyPath('', PropertyPath::UNPACK, ...$leftProperties);
-        $rightPropertyPath = new PropertyPath('', PropertyPath::UNPACK, ...$rightProperties);
+        $leftPropertyPath = new PropertyPath(null, '', PropertyPath::UNPACK, ...$leftProperties);
+        $rightPropertyPath = new PropertyPath(null, '', PropertyPath::UNPACK, ...$rightProperties);
         return new AllEqual(
             new Property($leftPropertyPath),
             new Property($rightPropertyPath)
@@ -63,7 +63,7 @@ class PhpConditionFactory implements ConditionFactoryInterface
 
     public function propertyBetweenValuesInclusive($min, $max, string $property, string ...$propertyPath): FunctionInterface
     {
-        $propertyPathObject = new PropertyPath('', PropertyPath::UNPACK, $property, ...$propertyPath);
+        $propertyPathObject = new PropertyPath(null, '', PropertyPath::UNPACK, $property, ...$propertyPath);
         return new BetweenInclusive(
             new Value($min),
             new Value($max),
@@ -73,7 +73,7 @@ class PhpConditionFactory implements ConditionFactoryInterface
 
     public function propertyHasAnyOfValues(array $values, string $property, string ...$properties): FunctionInterface
     {
-        $propertyPath = new PropertyPath('', PropertyPath::UNPACK, $property, ...$properties);
+        $propertyPath = new PropertyPath(null, '', PropertyPath::UNPACK, $property, ...$properties);
         return new OneOf(
             new Value($values),
             new Property($propertyPath)
@@ -82,7 +82,7 @@ class PhpConditionFactory implements ConditionFactoryInterface
 
     public function propertyHasSize(int $size, string $property, string ...$properties): FunctionInterface
     {
-        $propertyPath = new PropertyPath('', PropertyPath::DIRECT, $property, ...$properties);
+        $propertyPath = new PropertyPath(null, '', PropertyPath::DIRECT, $property, ...$properties);
         return new AllEqual(
             new Size(new Property($propertyPath)),
             new Value($size)
@@ -91,7 +91,7 @@ class PhpConditionFactory implements ConditionFactoryInterface
 
     public function propertyHasStringContainingCaseInsensitiveValue(string $value, string $property, string ...$properties): FunctionInterface
     {
-        $propertyPathInstance = new PropertyPath('', PropertyPath::UNPACK, $property, ...$properties);
+        $propertyPathInstance = new PropertyPath(null, '', PropertyPath::UNPACK, $property, ...$properties);
         $lowerCaseProperty = new LowerCase(new Property($propertyPathInstance));
         $lowerCaseValue = new LowerCase(new Value($value));
         return new StringContains($lowerCaseProperty, $lowerCaseValue);
@@ -99,7 +99,7 @@ class PhpConditionFactory implements ConditionFactoryInterface
 
     public function propertyHasValue($value, string $property, string ...$properties): FunctionInterface
     {
-        $propertyPath = new PropertyPath('', PropertyPath::DIRECT, $property, ...$properties);
+        $propertyPath = new PropertyPath(null, '', PropertyPath::DIRECT, $property, ...$properties);
         return new AllEqual(
             new Property($propertyPath),
             new Value($value)
@@ -108,13 +108,13 @@ class PhpConditionFactory implements ConditionFactoryInterface
 
     public function propertyIsNull(string $property, string ...$properties): FunctionInterface
     {
-        $propertyPath = new PropertyPath('', PropertyPath::UNPACK, $property, ...$properties);
+        $propertyPath = new PropertyPath(null, '', PropertyPath::UNPACK, $property, ...$properties);
         return new IsNull(new Property($propertyPath));
     }
 
     public function propertyHasStringAsMember(string $value, string $property, string ...$properties): FunctionInterface
     {
-        $propertyPathInstance = new PropertyPath('', PropertyPath::DIRECT, $property, ...$properties);
+        $propertyPathInstance = new PropertyPath(null, '', PropertyPath::DIRECT, $property, ...$properties);
         return new OneOf(
             new Property($propertyPathInstance),
             new Value($value)
@@ -123,7 +123,7 @@ class PhpConditionFactory implements ConditionFactoryInterface
 
     public function valueGreaterThan($value, string $property, string ...$properties): FunctionInterface
     {
-        $propertyPathInstance = new PropertyPath('', PropertyPath::DIRECT, $property, ...$properties);
+        $propertyPathInstance = new PropertyPath(null, '', PropertyPath::DIRECT, $property, ...$properties);
         return new Greater(
             new Value($value),
             new Property($propertyPathInstance)
@@ -132,7 +132,7 @@ class PhpConditionFactory implements ConditionFactoryInterface
 
     public function valueGreaterEqualsThan($value, string $property, string ...$properties): FunctionInterface
     {
-        $propertyPathInstance = new PropertyPath('', PropertyPath::DIRECT, $property, ...$properties);
+        $propertyPathInstance = new PropertyPath(null, '', PropertyPath::DIRECT, $property, ...$properties);
         return new GreaterEquals(
             new Value($value),
             new Property($propertyPathInstance)
@@ -141,7 +141,7 @@ class PhpConditionFactory implements ConditionFactoryInterface
 
     public function valueSmallerThan($value, string $property, string ...$properties): FunctionInterface
     {
-        $propertyPathInstance = new PropertyPath('', PropertyPath::DIRECT, $property, ...$properties);
+        $propertyPathInstance = new PropertyPath(null, '', PropertyPath::DIRECT, $property, ...$properties);
         return new Smaller(
             new Value($value),
             new Property($propertyPathInstance)
@@ -150,7 +150,7 @@ class PhpConditionFactory implements ConditionFactoryInterface
 
     public function valueSmallerEqualsThan($value, string $property, string ...$properties): FunctionInterface
     {
-        $propertyPathInstance = new PropertyPath('', PropertyPath::DIRECT, $property, ...$properties);
+        $propertyPathInstance = new PropertyPath(null, '', PropertyPath::DIRECT, $property, ...$properties);
         return new SmallerEquals(
             new Value($value),
             new Property($propertyPathInstance)
@@ -159,7 +159,7 @@ class PhpConditionFactory implements ConditionFactoryInterface
 
     public function propertyStartsWithCaseInsensitive($value, string $property, string ...$properties): FunctionInterface
     {
-        $propertyPathInstance = new PropertyPath('', PropertyPath::DIRECT, $property, ...$properties);
+        $propertyPathInstance = new PropertyPath(null, '', PropertyPath::DIRECT, $property, ...$properties);
         return new StringStartsWith(
             new Value($value),
             new Property($propertyPathInstance)
@@ -168,7 +168,7 @@ class PhpConditionFactory implements ConditionFactoryInterface
 
     public function propertyEndsWithCaseInsensitive($value, string $property, string ...$properties): FunctionInterface
     {
-        $propertyPathInstance = new PropertyPath('', PropertyPath::DIRECT, $property, ...$properties);
+        $propertyPathInstance = new PropertyPath(null, '', PropertyPath::DIRECT, $property, ...$properties);
         return new StringEndsWith(
             new Value($value),
             new Property($propertyPathInstance)

--- a/packages/queries/src/Contracts/PathException.php
+++ b/packages/queries/src/Contracts/PathException.php
@@ -17,4 +17,18 @@ class PathException extends Exception
         $pathString = implode('.', $fullPath);
         return new self("A path must not contain empty parts. Found in '$pathString'.");
     }
+
+    /**
+     * Prefixing of context-bound paths is not allowed, as they would become invalid in most
+     * use-cases.
+     *
+     * @param array<int, string> $prefix
+     *
+     * @throws PathException
+     */
+    public static function contextBoundPrefixing(PropertyPathAccessInterface $path, array $prefix): self
+    {
+        $prefixString = implode('.', $prefix);
+        return new self("Attempted to add prefix '$prefixString' to path '{$path->getAsNamesInDotNotation()}' with context '{$path->getContext()}'");
+    }
 }

--- a/packages/queries/src/Contracts/PropertyPathAccessInterface.php
+++ b/packages/queries/src/Contracts/PropertyPathAccessInterface.php
@@ -51,4 +51,9 @@ interface PropertyPathAccessInterface extends PropertyPathInterface
     public function getSalt(): string;
 
     public function __toString(): string;
+
+    /**
+     * @return class-string|null
+     */
+    public function getContext(): ?string;
 }

--- a/packages/queries/src/PropertyPaths/PropertyPath.php
+++ b/packages/queries/src/PropertyPaths/PropertyPath.php
@@ -33,10 +33,16 @@ class PropertyPath implements IteratorAggregate, PropertyPathAccessInterface
     private $salt;
 
     /**
+     * @var string|null
+     */
+    private $context;
+
+    /**
      * @throws PathException
      */
-    public function __construct(string $salt, int $accessDepth, string $property, string ...$properties)
+    public function __construct(?string $context, string $salt, int $accessDepth, string $property, string ...$properties)
     {
+        $this->context = $context;
         $this->accessDepth = $accessDepth;
         $this->setPath($property, ...$properties);
         $this->salt = $salt;
@@ -78,7 +84,7 @@ class PropertyPath implements IteratorAggregate, PropertyPathAccessInterface
     public static function createIndexSaltedPaths(int $count, int $depth, string $property, string ...$properties): array
     {
         return array_map(static function (int $pathIndex) use ($depth, $property, $properties): PropertyPathAccessInterface {
-            return new PropertyPath((string)$pathIndex, $depth, $property, ...$properties);
+            return new PropertyPath(null, (string)$pathIndex, $depth, $property, ...$properties);
         }, range(0, $count - 1));
     }
 
@@ -90,5 +96,10 @@ class PropertyPath implements IteratorAggregate, PropertyPathAccessInterface
     public function getAsNamesInDotNotation(): string
     {
         return implode('.', $this->getAsNames());
+    }
+
+    public function getContext(): ?string
+    {
+        return $this->context;
     }
 }

--- a/packages/queries/src/SortMethodFactories/PhpSortMethodFactory.php
+++ b/packages/queries/src/SortMethodFactories/PhpSortMethodFactory.php
@@ -15,13 +15,13 @@ class PhpSortMethodFactory implements SortMethodFactoryInterface
 {
     public function propertyAscending(string $property, string ...$properties): SortMethodInterface
     {
-        $propertyPathInstance = new PropertyPath('', PropertyPath::UNPACK_RECURSIVE, $property, ...$properties);
+        $propertyPathInstance = new PropertyPath(null, '', PropertyPath::UNPACK_RECURSIVE, $property, ...$properties);
         return new Ascending(new Property($propertyPathInstance));
     }
 
     public function propertyDescending(string $property, string ...$properties): SortMethodInterface
     {
-        $propertyPathInstance = new PropertyPath('', PropertyPath::UNPACK_RECURSIVE, $property, ...$properties);
+        $propertyPathInstance = new PropertyPath(null, '', PropertyPath::UNPACK_RECURSIVE, $property, ...$properties);
         return new Descending(new Property($propertyPathInstance));
     }
 }

--- a/packages/queries/src/Utilities/PathTransformer.php
+++ b/packages/queries/src/Utilities/PathTransformer.php
@@ -16,23 +16,41 @@ class PathTransformer
      * prepended to all paths within the given conditions.
      *
      * @param array<int, FunctionInterface> $conditions
+     *
+     * @throws PathException
      */
     public function prefixConditionPaths(array $conditions, string ...$prefix): void
     {
         array_walk($conditions, [$this, 'prefixConditionPath'], $prefix);
     }
 
+    /**
+     * @param array<int, string> $prefix
+     *
+     * @throws PathException
+     */
     public function prefixConditionPath(FunctionInterface $condition, int $key, array $prefix): void
     {
         $paths = $condition->getPropertyPaths();
+        $paths = array_filter(
+            Iterables::asArray($paths),
+            static function (PropertyPathAccessInterface $path): bool {
+                return null === $path->getContext();
+            }
+        );
         array_walk($paths, [$this, 'prefixPath'], $prefix);
     }
 
     /**
+     * @param array<int, string> $prefix
+     *
      * @throws PathException
      */
     public function prefixPath(PropertyPathAccessInterface $path, int $key, array $prefix): void
     {
+        if (null !== $path->getContext()) {
+            throw PathException::contextBoundPrefixing($path, $prefix);
+        }
         $path->setPath(...$prefix, ...$path);
     }
 }

--- a/packages/queries/src/Utilities/TableJoiner.php
+++ b/packages/queries/src/Utilities/TableJoiner.php
@@ -80,6 +80,10 @@ class TableJoiner
             }
 
             if ($propertyPath instanceof PropertyPathAccessInterface) {
+                if (null !== $propertyPath->getContext()) {
+                    throw new InvalidArgumentException("Custom path contexts are not supported in PHP evaluation yet.");
+                }
+
                 return $this->propertyAccessor->getValuesByPropertyPath(
                     $target,
                     $propertyPath->getAccessDepth(),
@@ -244,7 +248,8 @@ class TableJoiner
     {
         return Iterables::asArray($pathA) == Iterables::asArray($pathB)
             && $pathA->getAccessDepth() === $pathB->getAccessDepth()
-            && $pathA->getSalt() === $pathB->getSalt();
+            && $pathA->getSalt() === $pathB->getSalt()
+            && $pathA->getContext() === $pathB->getContext();
     }
 
     /**

--- a/packages/queries/tests/Querying/Evaluators/ConditionEvaluatorTest.php
+++ b/packages/queries/tests/Querying/Evaluators/ConditionEvaluatorTest.php
@@ -192,8 +192,8 @@ class ConditionEvaluatorTest extends ModelBasedTest
 
     public function testFunctionResultsEqualWithTwo(): void
     {
-        $pathA = new Property(new PropertyPath('', PropertyPath::UNPACK, 'birth', 'day'));
-        $pathB = new Property(new PropertyPath('', PropertyPath::UNPACK, 'birth', 'month'));
+        $pathA = new Property(new PropertyPath(null, '', PropertyPath::UNPACK, 'birth', 'day'));
+        $pathB = new Property(new PropertyPath(null, '', PropertyPath::UNPACK, 'birth', 'month'));
         $birthMonthAndDaySimilar = new AllEqual($pathA, $pathB);
         $expected = [$this->authors['salinger']];
         $filteredAuthors = array_values($this->conditionEvaluator->filterArray($this->authors, $birthMonthAndDaySimilar));
@@ -202,9 +202,9 @@ class ConditionEvaluatorTest extends ModelBasedTest
 
     public function testFunctionResultsEqualWithThree(): void
     {
-        $pathA = new Property(new PropertyPath('', PropertyPath::UNPACK, 'birth', 'day'));
-        $pathB = new Property(new PropertyPath('', PropertyPath::UNPACK, 'birth', 'month'));
-        $pathC = new Property(new PropertyPath('', PropertyPath::UNPACK, 'birth', 'year'));
+        $pathA = new Property(new PropertyPath(null, '', PropertyPath::UNPACK, 'birth', 'day'));
+        $pathB = new Property(new PropertyPath(null, '', PropertyPath::UNPACK, 'birth', 'month'));
+        $pathC = new Property(new PropertyPath(null, '', PropertyPath::UNPACK, 'birth', 'year'));
         $birthMonthAndDaySimilar = new AllEqual($pathA, $pathB, $pathC);
         $filteredAuthors = $this->conditionEvaluator->filterArray($this->authors, $birthMonthAndDaySimilar);
         self::assertEquals([], $filteredAuthors);
@@ -212,7 +212,7 @@ class ConditionEvaluatorTest extends ModelBasedTest
 
     public function testFunctionResultHasValue(): void
     {
-        $country = new Property(new PropertyPath('', PropertyPath::UNPACK, 'author', 'birth', 'country'));
+        $country = new Property(new PropertyPath(null, '', PropertyPath::UNPACK, 'author', 'birth', 'country'));
         $england = new Value('England');
         $propertyHasValue = new AllEqual($country, $england);
         $expectedBooks = [$this->books['pickwickPapers'], $this->books['philosopherStone'], $this->books['deathlyHallows']];
@@ -222,7 +222,7 @@ class ConditionEvaluatorTest extends ModelBasedTest
 
     public function testFunctionResultHasSize(): void
     {
-        $size = new Size(new Property(new PropertyPath('', PropertyPath::DIRECT, 'books')));
+        $size = new Size(new Property(new PropertyPath(null, '', PropertyPath::DIRECT, 'books')));
         $two = new Value(2);
         $hasSize = new AllEqual($size, $two);
         $expectedAuthors = [$this->authors['rowling']];
@@ -232,7 +232,7 @@ class ConditionEvaluatorTest extends ModelBasedTest
 
     public function testFunctionResultHasDoubleSizeWithSum(): void
     {
-        $size = new Size(new Property(new PropertyPath('', PropertyPath::DIRECT, 'books')));
+        $size = new Size(new Property(new PropertyPath(null, '', PropertyPath::DIRECT, 'books')));
         $doubleSize = new Sum($size, $size);
         $two = new Value(4);
         $hasSize = new AllEqual($doubleSize, $two);
@@ -244,7 +244,7 @@ class ConditionEvaluatorTest extends ModelBasedTest
     public function testFunctionLowerCase(): void
     {
         $constant = new Value('phen');
-        $property = new Property(new PropertyPath('', PropertyPath::UNPACK, 'name'));
+        $property = new Property(new PropertyPath(null, '', PropertyPath::UNPACK, 'name'));
         $lower = new LowerCase($property);
         $functionCondition = new StringContains($lower, $constant);
         $expectedAuthors = [$this->authors['king']];
@@ -255,7 +255,7 @@ class ConditionEvaluatorTest extends ModelBasedTest
     public function testFunctionLowerCaseFalse(): void
     {
         $constant = new Value('PHEN');
-        $property = new Property(new PropertyPath('', PropertyPath::UNPACK, 'name'));
+        $property = new Property(new PropertyPath(null, '', PropertyPath::UNPACK, 'name'));
         $lower = new LowerCase($property);
         $functionCondition = new StringContains($lower, $constant, true);
         $filteredAuthors = $this->conditionEvaluator->filterArray($this->authors, $functionCondition);
@@ -265,7 +265,7 @@ class ConditionEvaluatorTest extends ModelBasedTest
     public function testFunctionUpperCase(): void
     {
         $constant = new Value('PHEN');
-        $property = new Property(new PropertyPath('', PropertyPath::UNPACK, 'name'));
+        $property = new Property(new PropertyPath(null, '', PropertyPath::UNPACK, 'name'));
         $upper = new UpperCase($property);
         $functionCondition = new StringContains($upper, $constant);
         $expectedAuthors = [$this->authors['king']];
@@ -276,7 +276,7 @@ class ConditionEvaluatorTest extends ModelBasedTest
     public function testFunctionUpperCaseFalse(): void
     {
         $constant = new Value('phen');
-        $property = new Property(new PropertyPath('', PropertyPath::UNPACK, 'name'));
+        $property = new Property(new PropertyPath(null, '', PropertyPath::UNPACK, 'name'));
         $upper = new UpperCase($property);
         $functionCondition = new StringContains($upper, $constant, true);
         $filteredAuthors = $this->conditionEvaluator->filterArray($this->authors, $functionCondition);
@@ -285,7 +285,7 @@ class ConditionEvaluatorTest extends ModelBasedTest
 
     public function testFunctionResultHasDoubleSizeWithProduct(): void
     {
-        $size = new Size(new Property(new PropertyPath('', PropertyPath::DIRECT, 'books')));
+        $size = new Size(new Property(new PropertyPath(null, '', PropertyPath::DIRECT, 'books')));
         $doubleSize = new Product(new Value(2), $size);
         $two = new Value(4);
         $hasSize = new AllEqual($doubleSize, $two);
@@ -296,7 +296,7 @@ class ConditionEvaluatorTest extends ModelBasedTest
 
     public function testCustomMemberCondition(): void
     {
-        $propertyPath = new PropertyPath('', PropertyPath::DIRECT, 'books', 'title');
+        $propertyPath = new PropertyPath(null, '', PropertyPath::DIRECT, 'books', 'title');
         $condition = new AllTrue(
             new AllEqual(
                 new Property($propertyPath),
@@ -313,8 +313,8 @@ class ConditionEvaluatorTest extends ModelBasedTest
 
     public function testCustomMemberConditionWithSalt(): void
     {
-        $propertyPathA = new PropertyPath('a', PropertyPath::DIRECT, 'books', 'title');
-        $propertyPathB = new PropertyPath('b', PropertyPath::DIRECT, 'books', 'title');
+        $propertyPathA = new PropertyPath(null, 'a', PropertyPath::DIRECT, 'books', 'title');
+        $propertyPathB = new PropertyPath(null, 'b', PropertyPath::DIRECT, 'books', 'title');
         $condition = new AllTrue(
             new AllEqual(
                 new Property($propertyPathA),

--- a/packages/queries/tests/Querying/Paths/PropertyPathTest.php
+++ b/packages/queries/tests/Querying/Paths/PropertyPathTest.php
@@ -11,20 +11,20 @@ class PropertyPathTest extends TestCase
 {
     public function testPositiveAccessDepth(): void
     {
-        $instance = new PropertyPath('', 1, 'ab', 'cd', 'e');
+        $instance = new PropertyPath(null, '', 1, 'ab', 'cd', 'e');
         self::assertSame('ab.cd.e(1)', (string)$instance);
     }
 
     public function testNegativeAccessDepth(): void
     {
-        $instance = new PropertyPath('', -21, 'f', 'gh', 'i');
+        $instance = new PropertyPath(null, '', -21, 'f', 'gh', 'i');
         self::assertSame('f.gh.i(-21)', (string)$instance);
     }
 
     public function testComparison(): void
     {
-        $instanceA = new PropertyPath('', 1, 'ab', 'cd', 'e');
-        $instanceB = new PropertyPath('', 1, 'ab', 'cd', 'e');
+        $instanceA = new PropertyPath(null, '', 1, 'ab', 'cd', 'e');
+        $instanceB = new PropertyPath(null, '', 1, 'ab', 'cd', 'e');
         self::assertEquals($instanceA, $instanceB);
     }
 }

--- a/packages/queries/tests/Querying/Utilities/IterablesTest.php
+++ b/packages/queries/tests/Querying/Utilities/IterablesTest.php
@@ -146,8 +146,8 @@ class IterablesTest extends ModelBasedTest
     public function testRestructureIterableWithIterable1(): void
     {
         $input = [
-            new PropertyPath('', 0, 'a', 'b', 'c'),
-            new PropertyPath('', 0, 'd', 'e', 'f'),
+            new PropertyPath(null, '', 0, 'a', 'b', 'c'),
+            new PropertyPath(null, '', 0, 'd', 'e', 'f'),
         ];
 
         $expected = $input;
@@ -160,8 +160,8 @@ class IterablesTest extends ModelBasedTest
     public function testRestructureIterableWithIterable2(): void
     {
         $input = [
-            new PropertyPath('', 0, 'a', 'b', 'c'),
-            new PropertyPath('', 0, 'd', 'e', 'f'),
+            new PropertyPath(null, '', 0, 'a', 'b', 'c'),
+            new PropertyPath(null, '', 0, 'd', 'e', 'f'),
         ];
 
         $expected = ['a', 'b', 'c', 'd', 'e', 'f'];

--- a/packages/queries/tests/Querying/Utilities/TableJoinerTest.php
+++ b/packages/queries/tests/Querying/Utilities/TableJoinerTest.php
@@ -65,8 +65,8 @@ class TableJoinerTest extends ModelBasedTest
 
     public function testGetValueRowsWithMergedPaths(): void
     {
-        $bookPath = new PropertyPath('', PropertyPath::DIRECT, 'books');
-        $valueRows = $this->tableJoiner->getValueRows($this->authors['rowling'], $bookPath);
+        $bookPath = new PropertyPath(null, '', PropertyPath::DIRECT, 'books');
+        $valueRows = $this->tableJoiner->getValueRows($this->authors['rowling'], [$bookPath]);
         $expected = [$this->books['philosopherStone'], $this->books['deathlyHallows']];
         self::assertCount(1, $valueRows);
         $valueRow = $valueRows[0];
@@ -79,8 +79,8 @@ class TableJoinerTest extends ModelBasedTest
 
     public function testGetValueRows(): void
     {
-        $bookPath = new PropertyPath('', PropertyPath::DIRECT, 'books');
-        $valueRows = $this->tableJoiner->getValueRows($this->authors['rowling'], $bookPath);
+        $bookPath = new PropertyPath(null, '', PropertyPath::DIRECT, 'books');
+        $valueRows = $this->tableJoiner->getValueRows($this->authors['rowling'], [$bookPath]);
         $expected = [$this->books['philosopherStone'], $this->books['deathlyHallows']];
         self::assertCount(1, $valueRows);
         $valueRow = $valueRows[0];

--- a/packages/queries/tests/Querying/Utilities/TableJoinerTest.php
+++ b/packages/queries/tests/Querying/Utilities/TableJoinerTest.php
@@ -66,7 +66,7 @@ class TableJoinerTest extends ModelBasedTest
     public function testGetValueRowsWithMergedPaths(): void
     {
         $bookPath = new PropertyPath(null, '', PropertyPath::DIRECT, 'books');
-        $valueRows = $this->tableJoiner->getValueRows($this->authors['rowling'], [$bookPath]);
+        $valueRows = $this->tableJoiner->getValueRows($this->authors['rowling'], $bookPath);
         $expected = [$this->books['philosopherStone'], $this->books['deathlyHallows']];
         self::assertCount(1, $valueRows);
         $valueRow = $valueRows[0];
@@ -80,7 +80,7 @@ class TableJoinerTest extends ModelBasedTest
     public function testGetValueRows(): void
     {
         $bookPath = new PropertyPath(null, '', PropertyPath::DIRECT, 'books');
-        $valueRows = $this->tableJoiner->getValueRows($this->authors['rowling'], [$bookPath]);
+        $valueRows = $this->tableJoiner->getValueRows($this->authors['rowling'], $bookPath);
         $expected = [$this->books['philosopherStone'], $this->books['deathlyHallows']];
         self::assertCount(1, $valueRows);
         $valueRow = $valueRows[0];


### PR DESCRIPTION
Until now all paths used in conditions started at the same "main context" (i.e. entity class). So executing something like
```php
$propertiesEqual = $dqlConditionFactory->propertiesEqual(
    ['author', 'fullName'],
    ['title']
);
$entityProvider = new DoctrineOrmEntityProvider(Book::class, $entityManager);
// all books which have their title set to their authors name
$books = $entityProvider->getObjects([$propertiesEqual]);
```
would require `author` and `title` both exist in the entity class `Book`.

With this PR it becomes possible to use paths that are not reachable via properties in the main context. For example if we assume a `Book` has no relationship to `ShoppingBasket`, we can still find all books that are currently added to someones shopping basket, by setting the second path to a different context than the main context:
```php
$propertiesEqual = $dqlConditionFactory->propertiesEqual(
    ['id'],
    ['books', 'id'],
    ShoppingBasket::class
);
$entityProvider = new DoctrineOrmEntityProvider(Book::class, $entityManager);
$books = $entityProvider->getObjects([$propertiesEqual]);
```

For now only the `DqlConditionfactory::propertiesEqual` method exposes this feature, but it can be easily added to any other DQL condition.

As for PHP conditions there is no internal support yet. Trying to execute the condition above via PHP evaluation will result in an exception.
