### PR TITLE
feature: add DQL support for custom `select`s

### DIFF
--- a/packages/dql/src/Utilities/QueryGenerator.php
+++ b/packages/dql/src/Utilities/QueryGenerator.php
@@ -24,18 +24,20 @@ class QueryGenerator
     }
 
     /**
-     * @param class-string                $entityClass
-     * @param array<int,ClauseInterface>  $conditions
-     * @param array<int,OrderByInterface> $sortMethods
+     * @param class-string                  $entityClass
+     * @param array<int,ClauseInterface>    $conditions
+     * @param array<int,OrderByInterface>   $sortMethods
+     * @param array<string,ClauseInterface> $selections
      *
      * @throws MappingException
      * @throws SliceException
      */
-    public function generateQueryBuilder(string $entityClass, array $conditions, array $sortMethods = [], int $offset = 0, int $limit = null): QueryBuilder
+    public function generateQueryBuilder(string $entityClass, array $conditions, array $sortMethods = [], int $offset = 0, int $limit = null, array $selections = []): QueryBuilder
     {
         $queryBuilder = $this->entityManager->createQueryBuilder();
         $metadataFactory = $this->entityManager->getMetadataFactory();
         $builderPreparer = new QueryBuilderPreparer($entityClass, $metadataFactory);
+        $builderPreparer->setSelectExpressions($selections);
         $builderPreparer->setWhereExpressions(...$conditions);
         $builderPreparer->setOrderByExpressions(...$sortMethods);
         $builderPreparer->fillQueryBuilder($queryBuilder);

--- a/packages/dql/tests/DqlQuerying/Utilities/QueryGeneratorTest.php
+++ b/packages/dql/tests/DqlQuerying/Utilities/QueryGeneratorTest.php
@@ -85,6 +85,7 @@ class QueryGeneratorTest extends TestCase
         $trueCondition = $this->conditionFactory->true();
         $queryBuilder = $this->queryGenerator->generateQueryBuilder(Book::class, [$trueCondition]);
         self::assertSame(
+            /** @lang DQL */
             'SELECT Book FROM Tests\data\DqlModel\Book Book WHERE 1 = 1',
             $queryBuilder->getDQL()
         );
@@ -96,6 +97,7 @@ class QueryGeneratorTest extends TestCase
         $trueCondition = $this->conditionFactory->false();
         $queryBuilder = $this->queryGenerator->generateQueryBuilder(Book::class, [$trueCondition]);
         self::assertSame(
+            /** @lang DQL */
             'SELECT Book FROM Tests\data\DqlModel\Book Book WHERE 1 = 2',
             $queryBuilder->getDQL()
         );
@@ -109,6 +111,7 @@ class QueryGeneratorTest extends TestCase
         $allConditionsApply = $this->conditionFactory->anyConditionApplies($emptyTitleCondition, $nullTitleCondition);
         $queryBuilder = $this->queryGenerator->generateQueryBuilder(Book::class, [$allConditionsApply]);
         self::assertSame(
+            /** @lang DQL */
             'SELECT Book FROM Tests\data\DqlModel\Book Book WHERE Book.title = ?0 OR Book.title IS NULL',
             $queryBuilder->getDQL()
         );
@@ -126,6 +129,7 @@ class QueryGeneratorTest extends TestCase
         $allConditionsApply = $this->conditionFactory->allConditionsApply($bookA, $bookB);
         $queryBuilder = $this->queryGenerator->generateQueryBuilder(Person::class, [$allConditionsApply]);
         self::assertSame(
+            /** @lang DQL */
             'SELECT Person FROM Tests\data\DqlModel\Person Person LEFT JOIN Person.books t_3e6230ca_Book WHERE t_3e6230ca_Book.title = ?0 AND t_3e6230ca_Book.title = ?1',
             $queryBuilder->getDQL()
         );
@@ -142,6 +146,7 @@ class QueryGeneratorTest extends TestCase
         $propertyHasValue = $this->conditionFactory->propertyHasValue('Example Street', 'author', 'birth', 'street');
         $queryBuilder = $this->queryGenerator->generateQueryBuilder(Book::class, [$propertyHasValue]);
         self::assertSame(
+            /** @lang DQL */
             'SELECT Book FROM Tests\data\DqlModel\Book Book LEFT JOIN Book.author t_58fb870d_Person LEFT JOIN t_58fb870d_Person.birth t_7e118c84_Birth WHERE t_7e118c84_Birth.street = ?0',
             $queryBuilder->getDQL()
         );
@@ -163,6 +168,7 @@ class QueryGeneratorTest extends TestCase
             [$ascending, $descending]
         );
         self::assertSame(
+            /** @lang DQL */
             'SELECT Book FROM Tests\data\DqlModel\Book Book LEFT JOIN Book.author t_58fb870d_Person LEFT JOIN t_58fb870d_Person.birth t_7e118c84_Birth WHERE t_7e118c84_Birth.street = ?0 ORDER BY t_7e118c84_Birth.street ASC, Book.title DESC',
             $queryBuilder->getDQL()
         );
@@ -184,6 +190,7 @@ class QueryGeneratorTest extends TestCase
             [$descending, $ascending]
         );
         self::assertSame(
+            /** @lang DQL */
             'SELECT Book FROM Tests\data\DqlModel\Book Book LEFT JOIN Book.author t_58fb870d_Person LEFT JOIN t_58fb870d_Person.birth t_7e118c84_Birth WHERE t_7e118c84_Birth.street = ?0 ORDER BY t_7e118c84_Birth.street DESC, Book.title ASC',
             $queryBuilder->getDQL()
         );
@@ -206,6 +213,7 @@ class QueryGeneratorTest extends TestCase
             1, 3
         );
         self::assertSame(
+            /** @lang DQL */
             'SELECT Book FROM Tests\data\DqlModel\Book Book LEFT JOIN Book.author t_58fb870d_Person LEFT JOIN t_58fb870d_Person.birth t_7e118c84_Birth WHERE t_7e118c84_Birth.street = ?0 ORDER BY t_7e118c84_Birth.street ASC, Book.title DESC',
             $queryBuilder->getDQL()
         );
@@ -223,6 +231,7 @@ class QueryGeneratorTest extends TestCase
         $propertyIsNull = $this->conditionFactory->propertyIsNull('author', 'birth');
         $queryBuilder = $this->queryGenerator->generateQueryBuilder(Book::class, [$propertyIsNull]);
         self::assertSame(
+            /** @lang DQL */
             'SELECT Book FROM Tests\data\DqlModel\Book Book LEFT JOIN Book.author t_58fb870d_Person LEFT JOIN t_58fb870d_Person.birth t_7e118c84_Birth WHERE t_7e118c84_Birth IS NULL',
             $queryBuilder->getDQL()
         );
@@ -234,6 +243,7 @@ class QueryGeneratorTest extends TestCase
         $propertyIsNull = $this->conditionFactory->propertyIsNull('author', 'birth', 'street');
         $queryBuilder = $this->queryGenerator->generateQueryBuilder(Book::class, [$propertyIsNull]);
         self::assertSame(
+            /** @lang DQL */
             'SELECT Book FROM Tests\data\DqlModel\Book Book LEFT JOIN Book.author t_58fb870d_Person LEFT JOIN t_58fb870d_Person.birth t_7e118c84_Birth WHERE t_7e118c84_Birth.street IS NULL',
             $queryBuilder->getDQL()
         );
@@ -245,6 +255,7 @@ class QueryGeneratorTest extends TestCase
         $propertyHasSize = $this->conditionFactory->propertyHasSize(0, 'author');
         $queryBuilder = $this->queryGenerator->generateQueryBuilder(Book::class, [$propertyHasSize]);
         self::assertSame(
+            /** @lang DQL */
             'SELECT Book FROM Tests\data\DqlModel\Book Book WHERE SIZE(Book.author) = ?0',
             $queryBuilder->getDQL()
         );
@@ -260,6 +271,7 @@ class QueryGeneratorTest extends TestCase
         $propertyHasNotSize = $this->conditionFactory->propertyHasNotSize(0, 'books');
         $queryBuilder = $this->queryGenerator->generateQueryBuilder(Person::class, [$propertyHasNotSize]);
         self::assertSame(
+            /** @lang DQL */
             'SELECT Person FROM Tests\data\DqlModel\Person Person WHERE NOT(SIZE(Person.books) = ?0)',
             $queryBuilder->getDQL()
         );
@@ -275,6 +287,7 @@ class QueryGeneratorTest extends TestCase
         $propertyHasNotSize = $this->conditionFactory->propertyHasNotSize(0, 'author', 'books');
         $queryBuilder = $this->queryGenerator->generateQueryBuilder(Book::class, [$propertyHasNotSize]);
         self::assertSame(
+            /** @lang DQL */
             'SELECT Book FROM Tests\data\DqlModel\Book Book LEFT JOIN Book.author t_58fb870d_Person WHERE NOT(SIZE(t_58fb870d_Person.books) = ?0)',
             $queryBuilder->getDQL()
         );
@@ -290,6 +303,7 @@ class QueryGeneratorTest extends TestCase
         $propertyBetween = $this->conditionFactory->propertyBetweenValuesInclusive(-1, 5, 'author', 'birth', 'streetNumber');
         $queryBuilder = $this->queryGenerator->generateQueryBuilder(Book::class, [$propertyBetween]);
         self::assertSame(
+            /** @lang DQL */
             'SELECT Book FROM Tests\data\DqlModel\Book Book LEFT JOIN Book.author t_58fb870d_Person LEFT JOIN t_58fb870d_Person.birth t_7e118c84_Birth WHERE t_7e118c84_Birth.streetNumber BETWEEN ?0 AND ?1',
             $queryBuilder->getDQL()
         );
@@ -306,6 +320,7 @@ class QueryGeneratorTest extends TestCase
         $containsValue = $this->conditionFactory->propertyHasStringContainingCaseInsensitiveValue('Ave', 'author', 'birth', 'street');
         $queryBuilder = $this->queryGenerator->generateQueryBuilder(Book::class, [$containsValue]);
         self::assertSame(
+            /** @lang DQL */
             "SELECT Book FROM Tests\data\DqlModel\Book Book LEFT JOIN Book.author t_58fb870d_Person LEFT JOIN t_58fb870d_Person.birth t_7e118c84_Birth WHERE LOWER(t_7e118c84_Birth.street) LIKE CONCAT('%', LOWER(?0), '%')",
             $queryBuilder->getDQL()
         );
@@ -321,6 +336,7 @@ class QueryGeneratorTest extends TestCase
         $containsValue = $this->conditionFactory->propertyHasAnyOfValues([1, 2, 3], 'author', 'birth', 'streetNumber');
         $queryBuilder = $this->queryGenerator->generateQueryBuilder(Book::class, [$containsValue]);
         self::assertSame(
+            /** @lang DQL */
             'SELECT Book FROM Tests\data\DqlModel\Book Book LEFT JOIN Book.author t_58fb870d_Person LEFT JOIN t_58fb870d_Person.birth t_7e118c84_Birth WHERE t_7e118c84_Birth.streetNumber IN(?0)',
             $queryBuilder->getDQL()
         );
@@ -336,6 +352,7 @@ class QueryGeneratorTest extends TestCase
         $containsValue = $this->conditionFactory->propertyHasAnyOfValues([], 'author', 'birth', 'streetNumber');
         $queryBuilder = $this->queryGenerator->generateQueryBuilder(Book::class, [$containsValue]);
         self::assertSame(
+            /** @lang DQL */
             'SELECT Book FROM Tests\data\DqlModel\Book Book WHERE 1 = 2',
             $queryBuilder->getDQL()
         );
@@ -347,6 +364,7 @@ class QueryGeneratorTest extends TestCase
         $containsValue = $this->conditionFactory->propertyHasNotAnyOfValues([], 'author', 'birth', 'streetNumber');
         $queryBuilder = $this->queryGenerator->generateQueryBuilder(Book::class, [$containsValue]);
         self::assertSame(
+            /** @lang DQL */
             'SELECT Book FROM Tests\data\DqlModel\Book Book WHERE NOT(1 = 2)',
             $queryBuilder->getDQL()
         );
@@ -358,6 +376,7 @@ class QueryGeneratorTest extends TestCase
         $novelBook = $this->conditionFactory->propertyHasStringAsMember('Novel', 'tags');
         $queryBuilder = $this->queryGenerator->generateQueryBuilder(Book::class, [$novelBook]);
         self::assertSame(
+            /** @lang DQL */
             'SELECT Book FROM Tests\data\DqlModel\Book Book WHERE ?0 MEMBER OF Book.tags',
             $queryBuilder->getDQL()
         );
@@ -373,6 +392,7 @@ class QueryGeneratorTest extends TestCase
         $noNovelBook = $this->conditionFactory->propertyHasNotStringAsMember('Novel', 'tags');
         $queryBuilder = $this->queryGenerator->generateQueryBuilder(Book::class, [$noNovelBook]);
         self::assertSame(
+            /** @lang DQL */
             'SELECT Book FROM Tests\data\DqlModel\Book Book WHERE NOT(?0 MEMBER OF Book.tags)',
             $queryBuilder->getDQL()
         );
@@ -388,6 +408,7 @@ class QueryGeneratorTest extends TestCase
         $birthDateCondition = $this->conditionFactory->propertiesEqual(['author', 'birth', 'month'], ['author', 'birth', 'day']);
         $queryBuilder = $this->queryGenerator->generateQueryBuilder(Book::class, [$birthDateCondition]);
         self::assertSame(
+            /** @lang DQL */
             'SELECT Book FROM Tests\data\DqlModel\Book Book LEFT JOIN Book.author t_58fb870d_Person LEFT JOIN t_58fb870d_Person.birth t_7e118c84_Birth WHERE t_7e118c84_Birth.month = t_7e118c84_Birth.day',
             $queryBuilder->getDQL()
         );
@@ -403,6 +424,7 @@ class QueryGeneratorTest extends TestCase
         );
         $queryBuilder = $this->queryGenerator->generateQueryBuilder(Book::class, [$birthDateCondition]);
         self::assertSame(
+            /** @lang DQL */
             'SELECT Book FROM Tests\data\DqlModel\Book Book LEFT JOIN Book.author t_58fb870d_Person LEFT JOIN t_58fb870d_Person.birth t_7e118c84_Birth, Tests\data\DqlModel\Book t__Book LEFT JOIN t__Book.author t_71115441_Person LEFT JOIN t_71115441_Person.birth t_1a171a0d_Birth WHERE t_7e118c84_Birth.month = t_1a171a0d_Birth.day',
             $queryBuilder->getDQL()
         );
@@ -418,6 +440,7 @@ class QueryGeneratorTest extends TestCase
         );
         $queryBuilder = $this->queryGenerator->generateQueryBuilder(Book::class, [$sameUpperCase]);
         self::assertSame(
+            /** @lang DQL */
             'SELECT Book FROM Tests\data\DqlModel\Book Book WHERE UPPER(Book.title) = ?0',
             $queryBuilder->getDQL()
         );
@@ -438,6 +461,7 @@ class QueryGeneratorTest extends TestCase
         );
         $queryBuilder = $this->queryGenerator->generateQueryBuilder(Person::class, [$sum]);
         self::assertSame(
+            /** @lang DQL */
             'SELECT Person FROM Tests\data\DqlModel\Person Person WHERE SIZE(Person.name) + SIZE(Person.name) = ?0',
             $queryBuilder->getDQL()
         );
@@ -458,6 +482,7 @@ class QueryGeneratorTest extends TestCase
         );
         $queryBuilder = $this->queryGenerator->generateQueryBuilder(Person::class, [$sum]);
         self::assertSame(
+            /** @lang DQL */
             'SELECT Person FROM Tests\data\DqlModel\Person Person WHERE ((SIZE(Person.name) + SIZE(Person.name)) + SIZE(Person.name)) + SIZE(Person.name) = ?0',
             $queryBuilder->getDQL()
         );
@@ -485,6 +510,7 @@ class QueryGeneratorTest extends TestCase
         );
         $queryBuilder = $this->queryGenerator->generateQueryBuilder(Person::class, [$sum]);
         self::assertSame(
+            /** @lang DQL */
             'SELECT Person FROM Tests\data\DqlModel\Person Person WHERE ((SIZE(Person.name) + SIZE(Person.name)) * ?0) * (SIZE(Person.name) + SIZE(Person.name)) = (?1 + ((SIZE(Person.name) + SIZE(Person.name)) * ?2)) + ?3',
             $queryBuilder->getDQL()
         );
@@ -513,6 +539,7 @@ class QueryGeneratorTest extends TestCase
         );
         $queryBuilder = $this->queryGenerator->generateQueryBuilder(Person::class, [$condition]);
         self::assertSame(
+            /** @lang DQL */
             'SELECT Person FROM Tests\data\DqlModel\Person Person LEFT JOIN Person.books t_3e6230ca_Book WHERE ?0 = t_3e6230ca_Book.title AND ?1 = t_3e6230ca_Book.title',
             $queryBuilder->getDQL()
         );
@@ -540,6 +567,7 @@ class QueryGeneratorTest extends TestCase
         );
         $queryBuilder = $this->queryGenerator->generateQueryBuilder(Person::class, [$condition]);
         self::assertSame(
+            /** @lang DQL */
             'SELECT Person FROM Tests\data\DqlModel\Person Person LEFT JOIN Person.books t_99a6b3fc_Book LEFT JOIN Person.books t_246cdf32_Book WHERE t_99a6b3fc_Book.title = ?0 AND t_246cdf32_Book.title = ?1',
             $queryBuilder->getDQL()
         );
@@ -559,7 +587,47 @@ class QueryGeneratorTest extends TestCase
         ], 'books', 'title');
         $queryBuilder = $this->queryGenerator->generateQueryBuilder(Person::class, [$condition]);
         self::assertSame(
+            /** @lang DQL */
             'SELECT Person FROM Tests\data\DqlModel\Person Person LEFT JOIN Person.books t_4dba5d08_Book LEFT JOIN Person.books t_902c848d_Book WHERE t_4dba5d08_Book.title = ?0 AND t_902c848d_Book.title = ?1',
+            $queryBuilder->getDQL()
+        );
+
+        /** @var Collection<int, Parameter> $parameters */
+        $parameters = $queryBuilder->getParameters();
+        self::assertCount(2, $parameters);
+        self::assertSame("Harry Potter and the Philosopher's Stone", $parameters->first()->getValue());
+        self::assertSame('Harry Potter and the Deathly Hallows', $parameters->next()->getValue());
+    }
+
+    public function testAllValuesPresentInMemberListPropertiesWithSpecificSelect(): void
+    {
+        $birthDayPath = new PropertyPath(null, '', PropertyPath::DIRECT, 'birth', 'day');
+        $birthMonthPath = new PropertyPath(null, '', PropertyPath::DIRECT, 'birth', 'month');
+        $birthYearPath = new PropertyPath(null, '', PropertyPath::DIRECT, 'birth', 'year');
+
+        $selectBirthSum = new Sum(...array_map(static function (PropertyPath $propertyPath): Property {
+            return new Property($propertyPath);
+        }, [$birthDayPath, $birthMonthPath, $birthYearPath]));
+        $titlePath = new PropertyPath(null, '0', PropertyPath::DIRECT, 'books', 'title');
+        $selectTitleProperty = new Property($titlePath);
+        $namePath = new PropertyPath(null, '0', PropertyPath::DIRECT, 'name');
+        $selectNameProperty = new Property($namePath);
+
+        $condition = $this->conditionFactory->allValuesPresentInMemberListProperties([
+            'Harry Potter and the Philosopher\'s Stone',
+            'Harry Potter and the Deathly Hallows'
+        ], 'books', 'title');
+        $queryBuilder = $this->queryGenerator->generateQueryBuilder(
+            Person::class,
+            [$condition],
+            [],
+            0,
+            null,
+            ['name' => $selectNameProperty, 'birthSum' => $selectBirthSum, 'title' => $selectTitleProperty]
+        );
+        self::assertSame(
+            /** @lang DQL */
+            'SELECT Person.name AS name, (t_48c89847_Birth.day + t_48c89847_Birth.month) + t_48c89847_Birth.year AS birthSum, t_4dba5d08_Book.title AS title FROM Tests\data\DqlModel\Person Person LEFT JOIN Person.birth t_48c89847_Birth LEFT JOIN Person.books t_4dba5d08_Book LEFT JOIN Person.books t_902c848d_Book WHERE t_4dba5d08_Book.title = ?0 AND t_902c848d_Book.title = ?1',
             $queryBuilder->getDQL()
         );
 

--- a/packages/queries/tests/Querying/FluentQueries/FetchRequestBuilderFactoryTest.php
+++ b/packages/queries/tests/Querying/FluentQueries/FetchRequestBuilderFactoryTest.php
@@ -45,7 +45,7 @@ class FetchRequestBuilderFactoryTest extends ModelBasedTest
         return FluentQuery::createWithDefaultDefinitions($this->conditionFactory, $this->sortMethodFactory, $this->authorProvider);
     }
 
-    public function testRootAnd()
+    public function testRootAnd(): void
     {
         $fetch = $this->createFetchRequest();
         $fetch->getSortDefinition()


### PR DESCRIPTION
`QueryGenerator::generateQueryBuilder` now allows
to define custom `select`s instead of returning
instances of the main context entity class by
default. This enables not only to reduce the
returned data to specific properties, but also
to execute functions on the data in the DBMS.