### PR TITLE
#166 refactor (jsonapi)!: register types automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Unreleased
+
+### BC BREAK: register non-directly accessible types automatically
+
+The methods `registerType` and `registerTypes` were removed from `EDT/jsonapi/Manager`.
+Those were used as workaround to handle sparse fieldsets of non-directly accessible types correctly (i.e. types that were reachable via include only).
+The new approach will automatically register such types by investigating the relationships of directly accessible types.
+
+Calls to those methods can simply be deleted.
+No other migration action is required.
+
+### BC BREAK: add convenience method to interface
+
+Implementations of `PropertyReadableTypeProviderInterface` must now implement the method `addNamedType`.
+An example for a simple, but valid implementation can be found in `NameBasedTypeProvider`.
+
+If you don't implement `PropertyReadableTypeProviderInterface` yourself, no migration action is required.
+
 ## 0.26.0 - 2024-05-21
 
 > [!CAUTION]

--- a/packages/jsonapi/src/Manager.php
+++ b/packages/jsonapi/src/Manager.php
@@ -120,7 +120,7 @@ class Manager
     public function registerGetableType(GetableTypeInterface $type): void
     {
         $this->addToArray($type, $this->getableTypes);
-        $this->typeProvider->addType($type->getTypeName(), $type);
+        $this->typeProvider->addNamedType($type);
     }
 
     /**
@@ -137,7 +137,7 @@ class Manager
     public function registerListableType(ListableTypeInterface $type): void
     {
         $this->addToArray($type, $this->listableTypes);
-        $this->typeProvider->addType($type->getTypeName(), $type);
+        $this->typeProvider->addNamedType($type);
     }
 
     /**
@@ -146,7 +146,7 @@ class Manager
     public function registerUpdatableType(UpdatableTypeInterface $type): void
     {
         $this->addToArray($type, $this->updatableTypes);
-        $this->typeProvider->addType($type->getTypeName(), $type);
+        $this->typeProvider->addNamedType($type);
     }
 
     /**
@@ -155,14 +155,14 @@ class Manager
     public function registerCreatableType(CreatableTypeInterface $type): void
     {
         $this->addToArray($type, $this->creatableTypes);
-        $this->typeProvider->addType($type->getTypeName(), $type);
+        $this->typeProvider->addNamedType($type);
     }
 
     public function registerDeletableType(DeletableTypeInterface&NamedTypeInterface $type): void
     {
         $this->addToArray($type, $this->deletableTypes);
-        // no need to add it to the type provider, as it is only needed for sparse fieldsets,
-        // i.e. responses potentially containing resources
+	    // no need to note type for sparse fieldsets if it is only deletable, as deletions do not return a resource
+	    // if the same type is registered for a different action, it will be added to the type provider as usual
     }
 
     /**
@@ -195,44 +195,6 @@ class Manager
     public function registerDeletableTypes(array $types): void
     {
         array_map($this->registerDeletableType(...), $types);
-    }
-
-    /**
-     * Register a type whose resources should not be directly available via `get`, `list`, `create`, `update` or
-     * `delete`, but can still be included in a response beside the primary resources.
-     *
-     * Note that these types are still available via the relationships pointing to them. I.e. if `Book` resources
-     * can be fetched directly via `list` request and have a relationship to `Author` resources, then it may be possible
-     * to include the authors in the response, even if the `Author` resource type was not registered with this method.
-     * However, to ensure a consistent behavior in case of the usage of sparse fieldsets too, you must register them via
-     * this method.
-     *
-     * Do not call this method if your type is registered as directly available via the other register methods.
-     *
-     * @param PropertyReadableTypeInterface<object>&NamedTypeInterface $type
-     */
-    public function registerType(PropertyReadableTypeInterface&NamedTypeInterface $type): void
-    {
-        $this->typeProvider->addType($type->getTypeName(), $type);
-    }
-
-    /**
-     * Register types whose resources should not be directly available via `get`, `list`, `create`, `update` or
-     * `delete`, but can still be included in a response beside the primary resources.
-     *
-     * Note that these types are still available via the relationships pointing to them. I.e. if `Book` resources
-     * can be fetched directly via `list` request and have a relationship to `Author` resources, then it may be possible
-     * to include the authors in the response, even if the `Author` resource type was not registered with this method.
-     * However, to ensure a consistent behavior in case of the usage of sparse fieldsets too, you must register them via
-     * this method.
-     *
-     * Do not call this method if your types are registered as directly available via the other register methods.
-     *
-     * @param list<PropertyReadableTypeInterface<object>&NamedTypeInterface> $type
-     */
-    public function registerTypes(array $type): void
-    {
-        array_map($this->registerType(...), $type);
     }
 
     /**

--- a/packages/jsonapi/src/OutputHandling/PropertyReadableTypeProviderInterface.php
+++ b/packages/jsonapi/src/OutputHandling/PropertyReadableTypeProviderInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace EDT\JsonApi\OutputHandling;
 
 use EDT\Wrapping\Contracts\Types\PropertyReadableTypeInterface;
+use EDT\Wrapping\Contracts\Types\NamedTypeInterface;
 
 interface PropertyReadableTypeProviderInterface
 {
@@ -19,4 +20,9 @@ interface PropertyReadableTypeProviderInterface
      * @param PropertyReadableTypeInterface<object> $type
      */
     public function addType(string $typeName, PropertyReadableTypeInterface $type): void;
+
+    /**
+     * @param PropertyReadableTypeInterface<object>&NamedTypeInterface $type
+     */
+    public function addNamedType(PropertyReadableTypeInterface&NamedTypeInterface $type): void;
 }

--- a/packages/jsonapi/src/Utilities/NameBasedTypeProvider.php
+++ b/packages/jsonapi/src/Utilities/NameBasedTypeProvider.php
@@ -6,7 +6,9 @@ namespace EDT\JsonApi\Utilities;
 
 use EDT\JsonApi\OutputHandling\PropertyReadableTypeProviderInterface;
 use EDT\Wrapping\Contracts\Types\PropertyReadableTypeInterface;
+use InvalidArgumentException;
 use Webmozart\Assert\Assert;
+use EDT\Wrapping\Contracts\Types\NamedTypeInterface;
 
 class NameBasedTypeProvider implements PropertyReadableTypeProviderInterface
 {
@@ -17,8 +19,31 @@ class NameBasedTypeProvider implements PropertyReadableTypeProviderInterface
 
     public function addType(string $typeName, PropertyReadableTypeInterface $type): void
     {
-        Assert::keyNotExists($this->types, $typeName);
+        $existingType = $this->types[$typeName] ?? null;
+        // type already present, skip (we assume, that no new relationships appeared, since it was initially added to this instance)
+        if ($type === $existingType) {
+            return;
+    	}
+
+    	// type name used for a different type instance, abort
+        if (null !== $existingType) {
+            throw new InvalidArgumentException("A different type with the name `$typeName` was already added.");
+    	}
+    
+    	// type not yet present, add it and attempt to add its relationships
         $this->types[$typeName] = $type;
+    	foreach ($type->getReadability()->getRelationships() as $relationshipReadability) {
+            $relationshipType = $relationshipReadability->getRelationshipType();
+            if ($relationshipType instanceof PropertyReadableTypeInterface
+                && $relationshipType instanceof NamedTypeInterface) {
+                $this->addNamedType($relationshipType);
+            }
+        }
+    }
+
+    public function addNamedType(PropertyReadableTypeInterface&NamedTypeInterface $type): void
+    {
+        $this->addType($type->getTypeName(), $type);
     }
 
     public function getType(string $typeName): PropertyReadableTypeInterface


### PR DESCRIPTION
Non-directly reachable types are now registered
automatically. Directly reachable types still need to be registered regarding their accessibility, but
nested types will be registered automatically via
the relationship properties of other types.

Refs: #166