### PR TITLE
#168 refactor(repository): extract code into abstract class

### DIFF
--- a/packages/jsonapi/src/InputHandling/EntityProviderBasedRepository.php
+++ b/packages/jsonapi/src/InputHandling/EntityProviderBasedRepository.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EDT\JsonApi\InputHandling;
+
+use EDT\Querying\Contracts\OffsetEntityProviderInterface;
+use EDT\ConditionFactory\ConditionFactoryInterface;
+use InvalidArgumentException;
+use EDT\Querying\Pagination\PagePagination;
+use Pagerfanta\Pagerfanta;
+use EDT\Querying\Pagination\OffsetPagination;
+use Pagerfanta\Adapter\ArrayAdapter;
+
+/**
+ * @template TCondition the type of condition accepted by the logic accessing the actual data source (i.e. the given entity provider)
+ * @template TSorting the type of sort method accepted by the logic accessing the actual data source (i.e. the given entity provider)
+ * @template TEntity of object
+ *
+ * @template-implements RepositoryInterface<TEntity>
+ */
+abstract class EntityProviderBasedRepository implements RepositoryInterface
+{
+	/**
+	 * @param ConditionConverter<TCondition> $conditionConverter
+	 * @param SortMethodConverter<TSorting> $sortMethodConverter
+	 * @param ConditionFactoryInterface<TCondition> $conditionFactory
+	 * @param OffsetEntityProviderInterface<TCondition, TSorting, TEntity> $entityProvider
+	 */
+	public function __construct(
+	    protected readonly ConditionConverter $conditionConverter,
+	    protected readonly SortMethodConverter $sortMethodConverter,
+	    protected readonly ConditionFactoryInterface $conditionFactory,
+	    protected readonly OffsetEntityProviderInterface $entityProvider
+	) {}
+
+	public function getEntityByIdentifier(string $id, array $conditions, array $identifierPropertyPath): object
+	{
+	    $conditions = $this->conditionConverter->convertConditions($conditions);
+	    $conditions[] = $this->conditionFactory->propertyHasValue($id, $identifierPropertyPath);
+	    $entities = $this->entityProvider->getEntities($conditions, [], null);
+	    
+	    return match(count($entities)) {
+	        0 => throw new InvalidArgumentException('No entity found for the given ID and conditions.'),
+	        1 => array_pop($entities),
+	        default => throw new InvalidArgumentException('Multiple entities found matching the given ID and conditions.')
+	    };
+	}
+
+	public function getEntitiesByIdentifiers(array $identifiers, array $conditions, array $sortMethods, array $identifierPropertyPath): array
+	{
+	    $conditions = $this->conditionConverter->convertConditions($conditions);
+	    $sortMethods = $this->sortMethodConverter->convertSortMethods($sortMethods);
+	    $conditions[] = $this->conditionFactory->propertyHasAnyOfValues($identifiers, $identifierPropertyPath);
+	    
+	    return $this->entityProvider->getEntities($conditions, $sortMethods, null);
+	}
+
+	public function getEntities(array $conditions, array $sortMethods): array
+	{
+	    $conditions = $this->conditionConverter->convertConditions($conditions);
+	    $sortMethods = $this->sortMethodConverter->convertSortMethods($sortMethods);
+	    
+	    return $this->entityProvider->getEntities($conditions, $sortMethods, null);
+	}
+
+	public function getEntitiesForPage(array $conditions, array $sortMethods, PagePagination $pagination): Pagerfanta
+	{
+	    $conditions = $this->conditionConverter->convertConditions($conditions);
+	    $sortMethods = $this->sortMethodConverter->convertSortMethods($sortMethods);
+	    
+	    $pageSize = $pagination->getSize();
+	    $pageNumber = $pagination->getNumber();
+	    $paginator = new OffsetPagination(($pageNumber - 1) * $pageSize, $pageSize);
+	    $entities = $this->entityProvider->getEntities($conditions, $sortMethods, $paginator);
+	    
+	    return new Pagerfanta(new ArrayAdapter($entities));
+	}
+}

--- a/packages/jsonapi/src/InputHandling/PhpEntityRepository.php
+++ b/packages/jsonapi/src/InputHandling/PhpEntityRepository.php
@@ -10,38 +10,35 @@ use EDT\Querying\Contracts\FunctionInterface;
 use EDT\Querying\Contracts\PropertyAccessorInterface;
 use EDT\Querying\Contracts\SortMethodInterface;
 use EDT\Querying\ObjectProviders\MutableEntityProvider;
-use EDT\Querying\Pagination\OffsetPagination;
-use EDT\Querying\Pagination\PagePagination;
 use EDT\Querying\SortMethodFactories\PhpSortMethodFactory;
 use EDT\Querying\Utilities\ConditionEvaluator;
 use EDT\Querying\Utilities\Reindexer;
 use EDT\Querying\Utilities\Sorter;
 use EDT\Querying\Utilities\TableJoiner;
-use InvalidArgumentException;
-use Pagerfanta\Adapter\ArrayAdapter;
-use Pagerfanta\Pagerfanta;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
  * @template TEntity of object
  *
- * @template-implements RepositoryInterface<TEntity>
+ * @template-extends EntityProviderBasedRepository<FunctionInterface<bool>, SortMethodInterface, TEntity>
  */
-class PhpEntityRepository implements RepositoryInterface
+class PhpEntityRepository extends EntityProviderBasedRepository
 {
     /**
      * @param ConditionConverter<FunctionInterface<bool>> $conditionConverter
      * @param SortMethodConverter<SortMethodInterface> $sortMethodConverter
      * @param ConditionFactoryInterface<FunctionInterface<bool>> $conditionFactory
-     * @param MutableEntityProvider<TEntity> $entityProvider
+     * @param MutableEntityProvider<TEntity> $mutableEntityProvider
      */
     public function __construct(
-        protected readonly ConditionConverter $conditionConverter,
-        protected readonly SortMethodConverter $sortMethodConverter,
+        ConditionConverter $conditionConverter,
+        SortMethodConverter $sortMethodConverter,
         protected readonly Reindexer $reindexer,
-        protected readonly ConditionFactoryInterface $conditionFactory,
-        protected readonly MutableEntityProvider $entityProvider
-    ) {}
+        ConditionFactoryInterface $conditionFactory,
+        protected readonly MutableEntityProvider $mutableEntityProvider
+    ) {
+        parent::__construct($conditionConverter, $sortMethodConverter, $conditionFactory, $mutableEntityProvider);
+    }
 
     /**
      * @template TEnt of object
@@ -74,55 +71,13 @@ class PhpEntityRepository implements RepositoryInterface
         );
     }
 
-    public function getEntityByIdentifier(string $id, array $conditions, array $identifierPropertyPath): object
-    {
-        $conditions = $this->conditionConverter->convertConditions($conditions);
-        $conditions[] = $this->conditionFactory->propertyHasValue($id, $identifierPropertyPath);
-        $entities = $this->entityProvider->getEntities($conditions, [], null);
-
-        return match(count($entities)) {
-            0 => throw new InvalidArgumentException('No entity found for the given ID and conditions.'),
-            1 => array_pop($entities),
-            default => throw new InvalidArgumentException('Multiple entities found matching the given ID and conditions.')
-        };
-    }
-
-    public function getEntitiesByIdentifiers(array $identifiers, array $conditions, array $sortMethods, array $identifierPropertyPath): array
-    {
-        $conditions = $this->conditionConverter->convertConditions($conditions);
-        $sortMethods = $this->sortMethodConverter->convertSortMethods($sortMethods);
-        $conditions[] = $this->conditionFactory->propertyHasAnyOfValues($identifiers, $identifierPropertyPath);
-
-        return $this->entityProvider->getEntities($conditions, $sortMethods, null);
-    }
-
-    public function getEntities(array $conditions, array $sortMethods): array
-    {
-        $conditions = $this->conditionConverter->convertConditions($conditions);
-        $sortMethods = $this->sortMethodConverter->convertSortMethods($sortMethods);
-
-        return $this->entityProvider->getEntities($conditions, $sortMethods, null);
-    }
-
-    public function getEntitiesForPage(array $conditions, array $sortMethods, PagePagination $pagination): Pagerfanta
-    {
-        $conditions = $this->conditionConverter->convertConditions($conditions);
-        $sortMethods = $this->sortMethodConverter->convertSortMethods($sortMethods);
-
-        $pageSize = $pagination->getSize();
-        $pageNumber = $pagination->getNumber();
-        $paginator = new OffsetPagination(($pageNumber - 1) * $pageSize, $pageSize);
-        $entities = $this->entityProvider->getEntities($conditions, $sortMethods, $paginator);
-
-        return new Pagerfanta(new ArrayAdapter($entities));
-    }
 
     public function deleteEntityByIdentifier(string $entityIdentifier, array $conditions, array $identifierPropertyPath): void
     {
         $conditions = $this->conditionConverter->convertConditions($conditions);
 
         $conditions[] = $this->conditionFactory->propertyHasValue($entityIdentifier, $identifierPropertyPath);
-        $this->entityProvider->removeEntities($conditions, 1);
+        $this->mutableEntityProvider->removeEntities($conditions, 1);
     }
 
     public function reindexEntities(array $entities, array $conditions, array $sortMethods): array


### PR DESCRIPTION
Most of the code in `PhpEntityRepository` is relevant for other repositories based on an entity provider too. Hence, the re-usable logic was moved into a
newly created abstract class.

Refs: #168