### PR TITLE
Fix handle conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+- handle condition: in some cases however conditions do have values, we do need the OPERATORS 'IS NULL' and 'IS NOT NULL' and since they 
+  are only available in the condition without values, some filters are not working anymore.
+
 ## 0.24.42 - 2024-02-13
 
 * feature: add classes to programmatically create Drupal filters

--- a/packages/extra/src/Querying/ConditionParsers/Drupal/DrupalConditionParser.php
+++ b/packages/extra/src/Querying/ConditionParsers/Drupal/DrupalConditionParser.php
@@ -51,8 +51,15 @@ class DrupalConditionParser implements ConditionParserInterface
             return $pathSegment;
         }, explode('.', $pathString));
 
-        return array_key_exists(DrupalFilterParser::VALUE, $condition)
-            ? $this->drupalConditionFactory->createConditionWithValue($operatorName, $condition[DrupalFilterParser::VALUE], $path)
-            : $this->drupalConditionFactory->createConditionWithoutValue($operatorName, $path);
+        if (array_key_exists(DrupalFilterParser::VALUE, $condition )) {
+            if (!array_key_exists(DrupalFilterParser::OPERATOR, $condition )
+                || (array_key_exists(DrupalFilterParser::OPERATOR, $condition )
+                    && ($condition[DrupalFilterParser::OPERATOR] !== 'IS NULL'
+                        && $condition[DrupalFilterParser::OPERATOR] !== 'IS NOT NULL'))) {
+                return $this->drupalConditionFactory->createConditionWithValue($operatorName, $condition[DrupalFilterParser::VALUE], $path);
+            }
+        }
+
+        return $this->drupalConditionFactory->createConditionWithoutValue($operatorName, $path);
     }
 }

--- a/packages/extra/src/Querying/ConditionParsers/Drupal/DrupalConditionParser.php
+++ b/packages/extra/src/Querying/ConditionParsers/Drupal/DrupalConditionParser.php
@@ -51,15 +51,8 @@ class DrupalConditionParser implements ConditionParserInterface
             return $pathSegment;
         }, explode('.', $pathString));
 
-        if (array_key_exists(DrupalFilterParser::VALUE, $condition )) {
-            if (!array_key_exists(DrupalFilterParser::OPERATOR, $condition )
-                || (array_key_exists(DrupalFilterParser::OPERATOR, $condition )
-                    && ($condition[DrupalFilterParser::OPERATOR] !== 'IS NULL'
-                        && $condition[DrupalFilterParser::OPERATOR] !== 'IS NOT NULL'))) {
-                return $this->drupalConditionFactory->createConditionWithValue($operatorName, $condition[DrupalFilterParser::VALUE], $path);
-            }
-        }
-
-        return $this->drupalConditionFactory->createConditionWithoutValue($operatorName, $path);
+        return array_key_exists(DrupalFilterParser::VALUE, $condition)
+            ? $this->drupalConditionFactory->createConditionWithValue($operatorName, $condition[DrupalFilterParser::VALUE], $path)
+            : $this->drupalConditionFactory->createConditionWithoutValue($operatorName, $path);
     }
 }

--- a/packages/extra/src/Querying/ConditionParsers/Drupal/DrupalConditionParser.php
+++ b/packages/extra/src/Querying/ConditionParsers/Drupal/DrupalConditionParser.php
@@ -53,9 +53,8 @@ class DrupalConditionParser implements ConditionParserInterface
 
         if (array_key_exists(DrupalFilterParser::VALUE, $condition )) {
             if (!array_key_exists(DrupalFilterParser::OPERATOR, $condition )
-                || (array_key_exists(DrupalFilterParser::OPERATOR, $condition )
-                    && ($condition[DrupalFilterParser::OPERATOR] !== 'IS NULL'
-                        && $condition[DrupalFilterParser::OPERATOR] !== 'IS NOT NULL'))) {
+                || ($condition[DrupalFilterParser::OPERATOR] !== 'IS NULL'
+                        && $condition[DrupalFilterParser::OPERATOR] !== 'IS NOT NULL')) {
                 return $this->drupalConditionFactory->createConditionWithValue($operatorName, $condition[DrupalFilterParser::VALUE], $path);
             }
         }


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/issue/DPLAN-12254/Filter-Bearbeiter-Nicht-zugewiesen-funktioniert-nicht

Description:  in some cases however conditions do have values, we do need the OPERATORS 'IS NULL' and 'IS NOT NULL' and since they are only available in the condition without values, some filters are not working anymore