### PR TITLE
chore: fix deprecation in InputBag::get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* chore: fix deprecation in InputBag::get
+
 ## 0.25.0 - 2024-05-08
 
 ### BC BREAK: disallow empty lists for `propertyHasAnyOfValues` and `propertyHasNotAnyOfValues` methods

--- a/packages/jsonapi/src/Pagination/OffsetPaginationParser.php
+++ b/packages/jsonapi/src/Pagination/OffsetPaginationParser.php
@@ -34,7 +34,7 @@ class OffsetPaginationParser implements PaginationParserInterface
             return null;
         }
 
-        $page = $urlParameters->get(UrlParameter::PAGE);
+        $page = $urlParameters->all(UrlParameter::PAGE);
         $page = $this->getValidatedPage($page);
 
         /** @var int<0, max> $offset */

--- a/packages/jsonapi/src/Pagination/PagePaginationParser.php
+++ b/packages/jsonapi/src/Pagination/PagePaginationParser.php
@@ -39,7 +39,7 @@ class PagePaginationParser implements PaginationParserInterface
             return null;
         }
 
-        $page = $urlParameters->get(UrlParameter::PAGE);
+        $page = $urlParameters->all(UrlParameter::PAGE);
         $page = $this->getValidatedPage($page);
 
         /** @var positive-int $size */

--- a/packages/jsonapi/src/Requests/ListRequest.php
+++ b/packages/jsonapi/src/Requests/ListRequest.php
@@ -97,7 +97,7 @@ class ListRequest
             return [];
         }
 
-        $filterParam = $query->get(UrlParameter::FILTER);
+        $filterParam = $query->all(UrlParameter::FILTER);
         $query->remove(UrlParameter::FILTER);
         $filterParam = $this->filterParser->validateFilter($filterParam);
 


### PR DESCRIPTION
InputBag::get should only return scalar values, when an array is needed InputBag::all should be used. Like it or not. See symfony/symfony#44788 Needed for the upgrade to symfony 6

Fixes #174 